### PR TITLE
fix: remove binary from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 dist/
+
+# Local build of CLI (use releases or go build)
+scripts/syllable-cli/syllable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Machine-readable reference for AI agents using the Syllable CLI. The `syllable` binary manages all resources on the Syllable AI platform: agents, channels, prompts, tools, sessions, outbound campaigns/batches, users, directory, insights, custom messages, language groups, organizations, data sources, voice groups, services, roles, incidents, pronunciations, session labels, session debug, takeouts, events, permissions, conversation config, and dashboards.
 
-Binary location: `scripts/syllable-cli/syllable`
+Run via: `cd scripts/syllable-cli && go run .` or build with `go build -o syllable .` (no binary is checked in; use releases or local build).
 
 ---
 
@@ -105,7 +105,7 @@ cat ~/.syllable/config.yaml 2>/dev/null || echo "not configured"
 The CLI binary (`syllable`) is pre-built and checked into the repo — no compilation needed:
 
 ```bash
-scripts/syllable-cli/syllable --help
+cd scripts/syllable-cli && go run . --help
 ```
 
 If you need to rebuild after modifying source:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,14 @@ This repo contains the Syllable CLI — a Go tool for managing the Syllable AI p
 
 ## Binary
 
-Pre-built binary is at `scripts/syllable-cli/syllable`. Run it directly — no compilation needed.
+Run the CLI by building locally or from a release:
 
-To rebuild:
+**From source (no pre-built binary checked in):**
 ```bash
-cd scripts/syllable-cli && go build -o syllable .
+cd scripts/syllable-cli && go build -o syllable . && ./syllable --help
 ```
+
+Or install a release: `curl -fsSL https://github.com/asksyllable/syllable-cli/releases/latest/download/install.sh | sh`
 
 To run tests:
 ```bash


### PR DESCRIPTION
* dropped the prebuilt binary from the repo
* updated reference to build the binary
* added url reference to github releases for prebuilt binaries (not yet active)