### PR TITLE
build: move syllable-setup to release artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist/
 
-# Local build of CLI (use releases or go build)
+# Local builds (use releases or go build)
 scripts/syllable-cli/syllable
+scripts/syllable-setup/syllable-setup

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,6 +6,7 @@ before:
   hooks:
     - sh -c "cd scripts/syllable-cli && go mod tidy"
     - sh -c "cd scripts/syllable-cli && go test ./..."
+    - sh -c "cd scripts/syllable-setup && go mod tidy"
 
 builds:
   - id: syllable
@@ -15,6 +16,25 @@ builds:
     ldflags:
       - -s -w
       - -X github.com/asksyllable/syllable-cli/cmd.Version={{.Version}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+
+  - id: syllable-setup
+    dir: scripts/syllable-setup
+    main: .
+    binary: syllable-setup
+    ldflags:
+      - -s -w
     env:
       - CGO_ENABLED=0
     goos:
@@ -42,6 +62,15 @@ archives:
       - AGENTS.md
       - CLAUDE.md
       - LICENSE
+
+  - id: syllable-setup
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    name_template: "syllable-setup_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ Services
 Any time the user needs to configure the CLI — whether it's the first time, adding a new org, adding a new environment, or updating an API key — run the setup tool:
 
 ```bash
-cd scripts/syllable-setup && ./syllable-setup
+cd scripts/syllable-setup && go run .
 ```
 
 This opens a browser UI where the user can safely manage all orgs, API keys, and environments. Always use this tool for config changes — never edit `~/.syllable/config.yaml` directly or ask the user to paste API keys into the terminal.
@@ -102,7 +102,7 @@ cat ~/.syllable/config.yaml 2>/dev/null || echo "not configured"
 
 ## Quick Start
 
-The CLI binary (`syllable`) is pre-built and checked into the repo — no compilation needed:
+Run the CLI from source or a release (no binary is checked in):
 
 ```bash
 cd scripts/syllable-cli && go run . --help

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ cd scripts/syllable-cli && go test ./...
 
 ## Configuration
 
-Run `scripts/syllable-setup/syllable-setup` to open the browser-based config UI. This manages orgs, API keys, and environments in `~/.syllable/config.yaml`. Never edit that file directly or ask the user to paste keys into the terminal.
+Run the setup tool to open the browser-based config UI: `cd scripts/syllable-setup && go run .` (or `go build -o syllable-setup . && ./syllable-setup`). This manages orgs, API keys, and environments in `~/.syllable/config.yaml`. Never edit that file directly or ask the user to paste keys into the terminal.
 
 ## Key Flags
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Run the setup tool to configure orgs, API keys, and environments:
 
 ```bash
 cd scripts/syllable-setup
-./syllable-setup
+go run .
 ```
 
 This opens a browser UI. Use it any time you need to add an org, add an environment, or rotate a key. Do not edit `~/.syllable/config.yaml` by hand.

--- a/scripts/syllable-setup/go.mod
+++ b/scripts/syllable-setup/go.mod
@@ -2,9 +2,4 @@ module github.com/syllable-ai/syllable-setup
 
 go 1.21
 
-require (
-	golang.org/x/term v0.18.0
-	gopkg.in/yaml.v3 v3.0.1
-)
-
-require golang.org/x/sys v0.18.0 // indirect
+require gopkg.in/yaml.v3 v3.0.1

--- a/scripts/syllable-setup/go.sum
+++ b/scripts/syllable-setup/go.sum
@@ -1,7 +1,3 @@
-golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
-golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=
-golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
* dropped the prebuilt binary from the repo
* updated reference to build the binary
* added url reference to github releases for prebuilt binaries (not yet active)