### PR TITLE
chore: add CI workflow for unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Test
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: scripts/syllable-cli/go.mod
+          cache-dependency-path: scripts/syllable-cli/go.sum
+
+      - name: Run unit tests
+        working-directory: scripts/syllable-cli
+        run: go test $(go list ./... | grep -v /integration)


### PR DESCRIPTION
## What this adds

`.github/workflows/test.yml` — runs unit tests on every push and every PR targeting `main`.

## What runs

```
go test $(go list ./... | grep -v /integration)
```

This covers:
- `cmd` — uses a mock HTTP server, no credentials needed
- `internal/client`
- `internal/output`
- `internal/spec`

The `integration` package is excluded — it requires a live `SYLLABLE_API_KEY` and is meant to be run manually or in a separate workflow with secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)