### PR TITLE
feat: add Homebrew formula distribution

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -73,3 +73,21 @@ release:
     name: syllable-cli
   extra_files:
     - glob: "install.sh"
+
+brews:
+  - name: syllable
+    repository:
+      owner: asksyllable
+      name: syllable-cli
+      token: "{{ .Env.GITHUB_TOKEN }}"
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    commit_msg_template: "chore: update Homebrew formula for {{ .ProjectName }} {{ .Tag }}"
+    homepage: "https://github.com/asksyllable/syllable-cli"
+    description: "CLI for the Syllable AI platform"
+    license: "MIT"
+    install: |
+      bin.install "syllable"
+    test: |
+      system "#{bin}/syllable", "--version"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,20 @@ For deeper platform reference, see [docs.syllable.ai](https://docs.syllable.ai).
 
 ## Installation
 
-### Install script (macOS and Linux — recommended)
+### Homebrew (macOS and Linux — recommended)
+
+```bash
+brew tap asksyllable/syllable-cli https://github.com/asksyllable/syllable-cli
+brew install syllable
+```
+
+Upgrades are handled by Homebrew in the usual way:
+
+```bash
+brew upgrade syllable
+```
+
+### Install script (macOS and Linux)
 
 ```bash
 curl -fsSL https://github.com/asksyllable/syllable-cli/releases/latest/download/install.sh | sh


### PR DESCRIPTION
## What this adds

Homebrew formula support using the existing `asksyllable/syllable-cli` repo as the tap — no separate `homebrew-tap` repo needed.

On each release, GoReleaser automatically commits `Formula/syllable.rb` to this repo using the standard `GITHUB_TOKEN`. No new secrets required.

## Install command for customers

```bash
brew tap asksyllable/syllable-cli https://github.com/asksyllable/syllable-cli
brew install syllable
```

Upgrades:
```bash
brew upgrade syllable
```

## Notes

- GoReleaser warns that `brews` is being phased out in favour of a new key — config still validates and works. Can migrate in a follow-up once GoReleaser stabilises the replacement.
- The `Formula/syllable.rb` file will appear in this repo after the first release is tagged.
- README updated to show Homebrew as the recommended install method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)