### PR TITLE
fix: correct Homebrew install command to use cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,13 @@ For deeper platform reference, see [docs.syllable.ai](https://docs.syllable.ai).
 ### Homebrew (macOS and Linux — recommended)
 
 ```bash
-brew tap asksyllable/syllable-cli https://github.com/asksyllable/syllable-cli
-brew install syllable
+brew install --cask asksyllable/syllable-cli/syllable
 ```
 
 Upgrades are handled by Homebrew in the usual way:
 
 ```bash
-brew upgrade syllable
+brew upgrade --cask syllable
 ```
 
 ### Install script (macOS and Linux)


### PR DESCRIPTION
## Summary
- GoReleaser v2 generates a **Cask** (at `Casks/syllable.rb`), not a Formula
- The old `brew tap` + `brew install syllable` combo fails with "No available formula"
- Correct install is `brew install --cask asksyllable/syllable-cli/syllable`

## Test plan
- [ ] `brew install --cask asksyllable/syllable-cli/syllable` installs successfully
- [ ] `brew upgrade --cask syllable` upgrades correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)