### PR TITLE
fix: make org names case-insensitive

### DIFF
--- a/scripts/syllable-cli/cmd/root.go
+++ b/scripts/syllable-cli/cmd/root.go
@@ -290,9 +290,9 @@ func initClient() {
 // Priority (when --org is set): orgs.<org>.envs.<env>.api_key > orgs.<org>.api_key
 // Priority (no --org):          --api-key flag > SYLLABLE_API_KEY env var
 func resolveAPIKey() string {
-	org := viper.GetString("org")
+	org := strings.ToLower(viper.GetString("org"))
 	if org == "" {
-		org = viper.GetString("default_org")
+		org = strings.ToLower(viper.GetString("default_org"))
 	}
 
 	if org != "" {

--- a/scripts/syllable-cli/cmd/setup.go
+++ b/scripts/syllable-cli/cmd/setup.go
@@ -522,8 +522,9 @@ function buildOrgCard(orgName) {
 
   var nameInp = inp('text', orgName, 'org-name');
   nameInp.addEventListener('change', function() {
-    var old = saved.name; var n = nameInp.value.trim();
+    var old = saved.name; var n = nameInp.value.trim().toLowerCase();
     if (!n || n === old) return;
+    nameInp.value = n;
     var v = state.orgs[old]; delete state.orgs[old];
     state.orgs[n] = v;
     if (state.default_org === old) state.default_org = n;
@@ -645,10 +646,11 @@ function save(exit) {
   });
 
   // Strip top-level api_key from orgs — always save as explicit env rows.
+  // Force org names to lowercase for case-insensitive matching with --org flag.
   var orgsClean = {};
   Object.keys(state.orgs).forEach(function(n) {
     var org = state.orgs[n];
-    orgsClean[n] = {envs: org.envs || {}};
+    orgsClean[n.toLowerCase()] = {envs: org.envs || {}};
   });
 
   var payload = {


### PR DESCRIPTION
## Summary
Org names were case-sensitive — `--org Sandbox` would fail to find `sandbox` in the config.

- `setup` UI now forces org names to lowercase on rename and on save
- `resolveAPIKey()` lowercases the value from `--org` before config lookup (viper already lowercases map keys, so this ensures they always match)

## Test plan
- [ ] `syllable --org Sandbox agents list` works the same as `--org sandbox`
- [ ] `syllable setup` — typing an org name in mixed case normalizes to lowercase on blur
- [ ] Existing lowercase org configs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)