### PR TITLE
feat: add --search-field flag to all list commands

### DIFF
--- a/scripts/syllable-cli/cmd/agents.go
+++ b/scripts/syllable-cli/cmd/agents.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -49,7 +50,7 @@ func agentsCmd() *cobra.Command {
 
 func agentsListCmd() *cobra.Command {
 	var page, limit int
-	var search string
+	var search, searchField string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -57,7 +58,7 @@ func agentsListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := fmt.Sprintf("/api/v1/agents/?page=%d&limit=%d", page, limit)
 			if search != "" {
-				path += fmt.Sprintf("&search_fields=name&search_field_values=%s", search)
+				path += fmt.Sprintf("&search_fields=%s&search_field_values=%s", searchField, url.QueryEscape(search))
 			}
 
 			data, _, err := apiClient.Get(path)
@@ -107,6 +108,7 @@ func agentsListCmd() *cobra.Command {
 	cmd.Flags().IntVar(&page, "page", 0, "Page number (0-based)")
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max items to return")
 	cmd.Flags().StringVar(&search, "search", "", "Search by name")
+	cmd.Flags().StringVar(&searchField, "search-field", "name", "Field to search on (see API docs for valid values)")
 
 	return cmd
 }

--- a/scripts/syllable-cli/cmd/channels.go
+++ b/scripts/syllable-cli/cmd/channels.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -57,7 +58,7 @@ func channelsCmd() *cobra.Command {
 
 func channelsListCmd() *cobra.Command {
 	var page, limit int
-	var search string
+	var search, searchField string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -65,7 +66,7 @@ func channelsListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := fmt.Sprintf("/api/v1/channels/?page=%d&limit=%d", page, limit)
 			if search != "" {
-				path += fmt.Sprintf("&search_fields=name&search_field_values=%s", search)
+				path += fmt.Sprintf("&search_fields=%s&search_field_values=%s", searchField, url.QueryEscape(search))
 			}
 
 			data, _, err := apiClient.Get(path)
@@ -110,6 +111,7 @@ func channelsListCmd() *cobra.Command {
 	cmd.Flags().IntVar(&page, "page", 0, "Page number (0-based)")
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max items to return")
 	cmd.Flags().StringVar(&search, "search", "", "Search by name")
+	cmd.Flags().StringVar(&searchField, "search-field", "name", "Field to search on (see API docs for valid values)")
 
 	return cmd
 }
@@ -232,12 +234,16 @@ func channelsTargetsCmd() *cobra.Command {
 
 func channelsTargetsListCmd() *cobra.Command {
 	var page, limit int
+	var search, searchField string
 
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all channel targets",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := fmt.Sprintf("/api/v1/channels/targets?page=%d&limit=%d", page, limit)
+			if search != "" {
+				path += fmt.Sprintf("&search_fields=%s&search_field_values=%s", searchField, url.QueryEscape(search))
+			}
 
 			data, _, err := apiClient.Get(path)
 			if err != nil {
@@ -283,6 +289,8 @@ func channelsTargetsListCmd() *cobra.Command {
 
 	cmd.Flags().IntVar(&page, "page", 0, "Page number (0-based)")
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max items to return")
+	cmd.Flags().StringVar(&search, "search", "", "Search value (searches target phone number by default)")
+	cmd.Flags().StringVar(&searchField, "search-field", "target", "Field to search on (e.g. target, agent_id)")
 
 	return cmd
 }

--- a/scripts/syllable-cli/cmd/conversations.go
+++ b/scripts/syllable-cli/cmd/conversations.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -36,7 +37,7 @@ func conversationsCmd() *cobra.Command {
 
 func conversationsListCmd() *cobra.Command {
 	var page, limit int
-	var search, startDate, endDate string
+	var search, searchField, startDate, endDate string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -44,7 +45,7 @@ func conversationsListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := fmt.Sprintf("/api/v1/conversations/?page=%d&limit=%d", page, limit)
 			if search != "" {
-				path += fmt.Sprintf("&search_fields=agent_name&search_field_values=%s", search)
+				path += fmt.Sprintf("&search_fields=%s&search_field_values=%s", searchField, url.QueryEscape(search))
 			}
 			if startDate != "" {
 				path += fmt.Sprintf("&start_datetime=%s", startDate)
@@ -103,6 +104,7 @@ func conversationsListCmd() *cobra.Command {
 	cmd.Flags().IntVar(&page, "page", 0, "Page number (0-based)")
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max items to return")
 	cmd.Flags().StringVar(&search, "search", "", "Search by agent name")
+	cmd.Flags().StringVar(&searchField, "search-field", "agent_name", "Field to search on (see API docs for valid values)")
 	cmd.Flags().StringVar(&startDate, "start-date", "", "Start datetime filter (e.g. 2024-01-01T00:00:00Z)")
 	cmd.Flags().StringVar(&endDate, "end-date", "", "End datetime filter")
 

--- a/scripts/syllable-cli/cmd/custom_messages.go
+++ b/scripts/syllable-cli/cmd/custom_messages.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -43,7 +44,7 @@ func customMessagesCmd() *cobra.Command {
 
 func customMessagesListCmd() *cobra.Command {
 	var page, limit int
-	var search string
+	var search, searchField string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -51,7 +52,7 @@ func customMessagesListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := fmt.Sprintf("/api/v1/custom_messages/?page=%d&limit=%d", page, limit)
 			if search != "" {
-				path += fmt.Sprintf("&search_fields=name&search_field_values=%s", search)
+				path += fmt.Sprintf("&search_fields=%s&search_field_values=%s", searchField, url.QueryEscape(search))
 			}
 
 			data, _, err := apiClient.Get(path)
@@ -100,6 +101,7 @@ func customMessagesListCmd() *cobra.Command {
 	cmd.Flags().IntVar(&page, "page", 0, "Page number (0-based)")
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max items to return")
 	cmd.Flags().StringVar(&search, "search", "", "Search by name")
+	cmd.Flags().StringVar(&searchField, "search-field", "name", "Field to search on (see API docs for valid values)")
 
 	return cmd
 }

--- a/scripts/syllable-cli/cmd/data_sources.go
+++ b/scripts/syllable-cli/cmd/data_sources.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -46,7 +47,7 @@ func dataSourcesCmd() *cobra.Command {
 
 func dataSourcesListCmd() *cobra.Command {
 	var page, limit int
-	var search string
+	var search, searchField string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -54,7 +55,7 @@ func dataSourcesListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := fmt.Sprintf("/api/v1/data_sources/?page=%d&limit=%d", page, limit)
 			if search != "" {
-				path += fmt.Sprintf("&search_fields=name&search_field_values=%s", search)
+				path += fmt.Sprintf("&search_fields=%s&search_field_values=%s", searchField, url.QueryEscape(search))
 			}
 
 			data, _, err := apiClient.Get(path)
@@ -101,6 +102,7 @@ func dataSourcesListCmd() *cobra.Command {
 	cmd.Flags().IntVar(&page, "page", 0, "Page number (0-based)")
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max items to return")
 	cmd.Flags().StringVar(&search, "search", "", "Search by name")
+	cmd.Flags().StringVar(&searchField, "search-field", "name", "Field to search on (see API docs for valid values)")
 
 	return cmd
 }

--- a/scripts/syllable-cli/cmd/directory.go
+++ b/scripts/syllable-cli/cmd/directory.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -43,7 +44,7 @@ func directoryCmd() *cobra.Command {
 
 func directoryListCmd() *cobra.Command {
 	var page, limit int
-	var search string
+	var search, searchField string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -51,7 +52,7 @@ func directoryListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := fmt.Sprintf("/api/v1/directory_members/?page=%d&limit=%d", page, limit)
 			if search != "" {
-				path += fmt.Sprintf("&search_fields=name&search_field_values=%s", search)
+				path += fmt.Sprintf("&search_fields=%s&search_field_values=%s", searchField, url.QueryEscape(search))
 			}
 
 			data, _, err := apiClient.Get(path)
@@ -93,6 +94,7 @@ func directoryListCmd() *cobra.Command {
 	cmd.Flags().IntVar(&page, "page", 0, "Page number (0-based)")
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max items to return")
 	cmd.Flags().StringVar(&search, "search", "", "Search by name")
+	cmd.Flags().StringVar(&searchField, "search-field", "name", "Field to search on (see API docs for valid values)")
 
 	return cmd
 }

--- a/scripts/syllable-cli/cmd/incidents.go
+++ b/scripts/syllable-cli/cmd/incidents.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -47,7 +48,7 @@ func incidentsCmd() *cobra.Command {
 
 func incidentsListCmd() *cobra.Command {
 	var page, limit int
-	var search string
+	var search, searchField string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -55,7 +56,7 @@ func incidentsListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := fmt.Sprintf("/api/v1/incidents/?page=%d&limit=%d", page, limit)
 			if search != "" {
-				path += fmt.Sprintf("&search_fields=title&search_field_values=%s", search)
+				path += fmt.Sprintf("&search_fields=%s&search_field_values=%s", searchField, url.QueryEscape(search))
 			}
 
 			data, _, err := apiClient.Get(path)
@@ -105,6 +106,7 @@ func incidentsListCmd() *cobra.Command {
 	cmd.Flags().IntVar(&page, "page", 0, "Page number (0-based)")
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max items to return")
 	cmd.Flags().StringVar(&search, "search", "", "Search by title")
+	cmd.Flags().StringVar(&searchField, "search-field", "title", "Field to search on (see API docs for valid values)")
 
 	return cmd
 }

--- a/scripts/syllable-cli/cmd/insights.go
+++ b/scripts/syllable-cli/cmd/insights.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -66,7 +67,7 @@ func insightsWorkflowsCmd() *cobra.Command {
 
 func insightsWorkflowsListCmd() *cobra.Command {
 	var page, limit int
-	var search string
+	var search, searchField string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -74,7 +75,7 @@ func insightsWorkflowsListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := fmt.Sprintf("/api/v1/insights/workflows/?page=%d&limit=%d", page, limit)
 			if search != "" {
-				path += fmt.Sprintf("&search_fields=name&search_field_values=%s", search)
+				path += fmt.Sprintf("&search_fields=%s&search_field_values=%s", searchField, url.QueryEscape(search))
 			}
 
 			data, _, err := apiClient.Get(path)
@@ -118,6 +119,7 @@ func insightsWorkflowsListCmd() *cobra.Command {
 	cmd.Flags().IntVar(&page, "page", 0, "Page number (0-based)")
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max items to return")
 	cmd.Flags().StringVar(&search, "search", "", "Search by name")
+	cmd.Flags().StringVar(&searchField, "search-field", "name", "Field to search on (see API docs for valid values)")
 
 	return cmd
 }
@@ -561,11 +563,19 @@ func insightsToolConfigsCmd() *cobra.Command {
 }
 
 func insightsToolConfigsListCmd() *cobra.Command {
-	return &cobra.Command{
+	var page, limit int
+	var search, searchField string
+
+	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List insight tool configurations",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/insights/tool-configurations")
+			path := fmt.Sprintf("/api/v1/insights/tool-configurations?page=%d&limit=%d", page, limit)
+			if search != "" {
+				path += fmt.Sprintf("&search_fields=%s&search_field_values=%s", searchField, url.QueryEscape(search))
+			}
+
+			data, _, err := apiClient.Get(path)
 			if err != nil {
 				return err
 			}
@@ -573,6 +583,13 @@ func insightsToolConfigsListCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().IntVar(&page, "page", 0, "Page number (0-based)")
+	cmd.Flags().IntVar(&limit, "limit", 25, "Max items to return")
+	cmd.Flags().StringVar(&search, "search", "", "Search by name")
+	cmd.Flags().StringVar(&searchField, "search-field", "name", "Field to search on (see API docs for valid values)")
+
+	return cmd
 }
 
 func insightsToolConfigsGetCmd() *cobra.Command {

--- a/scripts/syllable-cli/cmd/language_groups.go
+++ b/scripts/syllable-cli/cmd/language_groups.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -43,7 +44,7 @@ func languageGroupsCmd() *cobra.Command {
 
 func languageGroupsListCmd() *cobra.Command {
 	var page, limit int
-	var search string
+	var search, searchField string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -51,7 +52,7 @@ func languageGroupsListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := fmt.Sprintf("/api/v1/language_groups/?page=%d&limit=%d", page, limit)
 			if search != "" {
-				path += fmt.Sprintf("&search_fields=name&search_field_values=%s", search)
+				path += fmt.Sprintf("&search_fields=%s&search_field_values=%s", searchField, url.QueryEscape(search))
 			}
 
 			data, _, err := apiClient.Get(path)
@@ -98,6 +99,7 @@ func languageGroupsListCmd() *cobra.Command {
 	cmd.Flags().IntVar(&page, "page", 0, "Page number (0-based)")
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max items to return")
 	cmd.Flags().StringVar(&search, "search", "", "Search by name")
+	cmd.Flags().StringVar(&searchField, "search-field", "name", "Field to search on (see API docs for valid values)")
 
 	return cmd
 }

--- a/scripts/syllable-cli/cmd/outbound.go
+++ b/scripts/syllable-cli/cmd/outbound.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -65,7 +66,7 @@ func outboundBatchesCmd() *cobra.Command {
 
 func outboundBatchesListCmd() *cobra.Command {
 	var page, limit int
-	var search string
+	var search, searchField string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -73,7 +74,7 @@ func outboundBatchesListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := fmt.Sprintf("/api/v1/outbound/batches?page=%d&limit=%d", page, limit)
 			if search != "" {
-				path += fmt.Sprintf("&search_fields=batch_id&search_field_values=%s", search)
+				path += fmt.Sprintf("&search_fields=%s&search_field_values=%s", searchField, url.QueryEscape(search))
 			}
 
 			data, _, err := apiClient.Get(path)
@@ -127,6 +128,7 @@ func outboundBatchesListCmd() *cobra.Command {
 	cmd.Flags().IntVar(&page, "page", 0, "Page number (0-based)")
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max items to return")
 	cmd.Flags().StringVar(&search, "search", "", "Search by batch ID")
+	cmd.Flags().StringVar(&searchField, "search-field", "batch_id", "Field to search on (see API docs for valid values)")
 
 	return cmd
 }
@@ -399,7 +401,7 @@ func outboundCampaignsCmd() *cobra.Command {
 
 func outboundCampaignsListCmd() *cobra.Command {
 	var page, limit int
-	var search string
+	var search, searchField string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -407,7 +409,7 @@ func outboundCampaignsListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := fmt.Sprintf("/api/v1/outbound/campaigns?page=%d&limit=%d", page, limit)
 			if search != "" {
-				path += fmt.Sprintf("&search_fields=campaign_name&search_field_values=%s", search)
+				path += fmt.Sprintf("&search_fields=%s&search_field_values=%s", searchField, url.QueryEscape(search))
 			}
 
 			data, _, err := apiClient.Get(path)
@@ -457,6 +459,7 @@ func outboundCampaignsListCmd() *cobra.Command {
 	cmd.Flags().IntVar(&page, "page", 0, "Page number (0-based)")
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max items to return")
 	cmd.Flags().StringVar(&search, "search", "", "Search by campaign name")
+	cmd.Flags().StringVar(&searchField, "search-field", "campaign_name", "Field to search on (see API docs for valid values)")
 
 	return cmd
 }

--- a/scripts/syllable-cli/cmd/prompts.go
+++ b/scripts/syllable-cli/cmd/prompts.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -45,7 +46,7 @@ func promptsCmd() *cobra.Command {
 
 func promptsListCmd() *cobra.Command {
 	var page, limit int
-	var search string
+	var search, searchField string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -53,7 +54,7 @@ func promptsListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := fmt.Sprintf("/api/v1/prompts/?page=%d&limit=%d", page, limit)
 			if search != "" {
-				path += fmt.Sprintf("&search_fields=name&search_field_values=%s", search)
+				path += fmt.Sprintf("&search_fields=%s&search_field_values=%s", searchField, url.QueryEscape(search))
 			}
 
 			data, _, err := apiClient.Get(path)
@@ -105,6 +106,7 @@ func promptsListCmd() *cobra.Command {
 	cmd.Flags().IntVar(&page, "page", 0, "Page number (0-based)")
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max items to return")
 	cmd.Flags().StringVar(&search, "search", "", "Search by name")
+	cmd.Flags().StringVar(&searchField, "search-field", "name", "Field to search on (see API docs for valid values)")
 
 	return cmd
 }

--- a/scripts/syllable-cli/cmd/roles.go
+++ b/scripts/syllable-cli/cmd/roles.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -46,7 +47,7 @@ func rolesCmd() *cobra.Command {
 
 func rolesListCmd() *cobra.Command {
 	var page, limit int
-	var search string
+	var search, searchField string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -54,7 +55,7 @@ func rolesListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := fmt.Sprintf("/api/v1/roles/?page=%d&limit=%d", page, limit)
 			if search != "" {
-				path += fmt.Sprintf("&search_fields=name&search_field_values=%s", search)
+				path += fmt.Sprintf("&search_fields=%s&search_field_values=%s", searchField, url.QueryEscape(search))
 			}
 
 			data, _, err := apiClient.Get(path)
@@ -101,6 +102,7 @@ func rolesListCmd() *cobra.Command {
 	cmd.Flags().IntVar(&page, "page", 0, "Page number (0-based)")
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max items to return")
 	cmd.Flags().StringVar(&search, "search", "", "Search by name")
+	cmd.Flags().StringVar(&searchField, "search-field", "name", "Field to search on (see API docs for valid values)")
 
 	return cmd
 }

--- a/scripts/syllable-cli/cmd/services.go
+++ b/scripts/syllable-cli/cmd/services.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -46,7 +47,7 @@ func servicesCmd() *cobra.Command {
 
 func servicesListCmd() *cobra.Command {
 	var page, limit int
-	var search string
+	var search, searchField string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -54,7 +55,7 @@ func servicesListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := fmt.Sprintf("/api/v1/services/?page=%d&limit=%d", page, limit)
 			if search != "" {
-				path += fmt.Sprintf("&search_fields=name&search_field_values=%s", search)
+				path += fmt.Sprintf("&search_fields=%s&search_field_values=%s", searchField, url.QueryEscape(search))
 			}
 
 			data, _, err := apiClient.Get(path)
@@ -101,6 +102,7 @@ func servicesListCmd() *cobra.Command {
 	cmd.Flags().IntVar(&page, "page", 0, "Page number (0-based)")
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max items to return")
 	cmd.Flags().StringVar(&search, "search", "", "Search by name")
+	cmd.Flags().StringVar(&searchField, "search-field", "name", "Field to search on (see API docs for valid values)")
 
 	return cmd
 }

--- a/scripts/syllable-cli/cmd/sessions.go
+++ b/scripts/syllable-cli/cmd/sessions.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -50,7 +51,7 @@ func sessionsCmd() *cobra.Command {
 
 func sessionsListCmd() *cobra.Command {
 	var page, limit int
-	var search, startDate, endDate string
+	var search, searchField, startDate, endDate string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -58,7 +59,7 @@ func sessionsListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := fmt.Sprintf("/api/v1/sessions/?page=%d&limit=%d", page, limit)
 			if search != "" {
-				path += fmt.Sprintf("&search_fields=agent_name&search_field_values=%s", search)
+				path += fmt.Sprintf("&search_fields=%s&search_field_values=%s", searchField, url.QueryEscape(search))
 			}
 			if startDate != "" {
 				path += fmt.Sprintf("&start_datetime=%s", startDate)
@@ -125,6 +126,7 @@ func sessionsListCmd() *cobra.Command {
 	cmd.Flags().IntVar(&page, "page", 0, "Page number (0-based)")
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max items to return")
 	cmd.Flags().StringVar(&search, "search", "", "Search by agent name")
+	cmd.Flags().StringVar(&searchField, "search-field", "agent_name", "Field to search on (see API docs for valid values)")
 	cmd.Flags().StringVar(&startDate, "start-date", "", "Start datetime filter (e.g. 2024-01-01T00:00:00Z)")
 	cmd.Flags().StringVar(&endDate, "end-date", "", "End datetime filter")
 

--- a/scripts/syllable-cli/cmd/tools.go
+++ b/scripts/syllable-cli/cmd/tools.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -40,7 +41,7 @@ func toolsCmd() *cobra.Command {
 
 func toolsListCmd() *cobra.Command {
 	var page, limit int
-	var search string
+	var search, searchField string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -48,7 +49,7 @@ func toolsListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := fmt.Sprintf("/api/v1/tools/?page=%d&limit=%d", page, limit)
 			if search != "" {
-				path += fmt.Sprintf("&search_fields=name&search_field_values=%s", search)
+				path += fmt.Sprintf("&search_fields=%s&search_field_values=%s", searchField, url.QueryEscape(search))
 			}
 
 			data, _, err := apiClient.Get(path)
@@ -97,6 +98,7 @@ func toolsListCmd() *cobra.Command {
 	cmd.Flags().IntVar(&page, "page", 0, "Page number (0-based)")
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max items to return")
 	cmd.Flags().StringVar(&search, "search", "", "Search by name")
+	cmd.Flags().StringVar(&searchField, "search-field", "name", "Field to search on (see API docs for valid values)")
 
 	return cmd
 }

--- a/scripts/syllable-cli/cmd/users.go
+++ b/scripts/syllable-cli/cmd/users.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -51,7 +52,7 @@ func usersCmd() *cobra.Command {
 
 func usersListCmd() *cobra.Command {
 	var page, limit int
-	var search string
+	var search, searchField string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -59,7 +60,7 @@ func usersListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := fmt.Sprintf("/api/v1/users/?page=%d&limit=%d", page, limit)
 			if search != "" {
-				path += fmt.Sprintf("&search_fields=email&search_field_values=%s", search)
+				path += fmt.Sprintf("&search_fields=%s&search_field_values=%s", searchField, url.QueryEscape(search))
 			}
 
 			data, _, err := apiClient.Get(path)
@@ -120,6 +121,7 @@ func usersListCmd() *cobra.Command {
 	cmd.Flags().IntVar(&page, "page", 0, "Page number (0-based)")
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max items to return")
 	cmd.Flags().StringVar(&search, "search", "", "Search by email")
+	cmd.Flags().StringVar(&searchField, "search-field", "email", "Field to search on (see API docs for valid values)")
 
 	return cmd
 }

--- a/scripts/syllable-cli/cmd/voice_groups.go
+++ b/scripts/syllable-cli/cmd/voice_groups.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -46,7 +47,7 @@ func voiceGroupsCmd() *cobra.Command {
 
 func voiceGroupsListCmd() *cobra.Command {
 	var page, limit int
-	var search string
+	var search, searchField string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -54,7 +55,7 @@ func voiceGroupsListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := fmt.Sprintf("/api/v1/voice_groups/?page=%d&limit=%d", page, limit)
 			if search != "" {
-				path += fmt.Sprintf("&search_fields=name&search_field_values=%s", search)
+				path += fmt.Sprintf("&search_fields=%s&search_field_values=%s", searchField, url.QueryEscape(search))
 			}
 
 			data, _, err := apiClient.Get(path)
@@ -101,6 +102,7 @@ func voiceGroupsListCmd() *cobra.Command {
 	cmd.Flags().IntVar(&page, "page", 0, "Page number (0-based)")
 	cmd.Flags().IntVar(&limit, "limit", 25, "Max items to return")
 	cmd.Flags().StringVar(&search, "search", "", "Search by name")
+	cmd.Flags().StringVar(&searchField, "search-field", "name", "Field to search on (see API docs for valid values)")
 
 	return cmd
 }


### PR DESCRIPTION
## Summary

- All `list` commands previously hardcoded the search field (e.g. `name`, `agent_name`, `email`). This change adds a `--search-field` flag to every list command that supports the `search_fields`/`search_field_values` API query params, defaulting to the previous hardcoded value so existing usage is unchanged.
- Also adds `url.QueryEscape` to all search values so phone numbers and other special characters (e.g. `+16195551234`) are sent correctly.
- Derived from the OpenAPI spec — valid field values per endpoint are documented at `syllable schema get <type>`.

**Affected commands:** agents, channels, channels targets, conversations, custom-messages, data-sources, directory-members, incidents, insights workflows, insights tool-configs, language-groups, outbound batches, outbound campaigns, prompts, roles, services, sessions, tools, users, voice-groups.

## Example

```bash
# Search channel targets by phone number (new default field: target)
syllable channels targets list --search "+16196496319"

# Search sessions by agent ID instead of agent name
syllable sessions list --search "132" --search-field agent_id
```

## Test plan

- [ ] `syllable channels targets list --search "+16196496319"` returns correct result
- [ ] Existing `--search <name>` usage on agents, prompts, tools etc. still works unchanged
- [ ] `--search-field` with a non-default field (e.g. `agent_id`) returns correct results

🤖 Generated with [Claude Code](https://claude.com/claude-code)