### PR TITLE
fix: better error when --env missing for org with per-env keys

### DIFF
--- a/scripts/syllable-cli/cmd/root.go
+++ b/scripts/syllable-cli/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -312,7 +313,17 @@ func resolveAPIKey() string {
 	// org-level key
 	k, _ := orgMap["api_key"].(string)
 	if k == "" {
-		fmt.Fprintf(os.Stderr, "Error: no api_key found for org %q in ~/.syllable/config.yaml — run `syllable setup` to configure it\n", org)
+		// If the org has per-env keys but no env was specified, give a targeted error.
+		if envs, ok := orgMap["envs"].(map[string]interface{}); ok && len(envs) > 0 {
+			names := make([]string, 0, len(envs))
+			for e := range envs {
+				names = append(names, e)
+			}
+			sort.Strings(names)
+			fmt.Fprintf(os.Stderr, "Error: org %q has per-environment keys (%s) but no environment was specified.\nUse --env <name> or set default_env in `syllable setup`.\n", org, strings.Join(names, ", "))
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: no api_key found for org %q — run `syllable setup` to configure it\n", org)
+		}
 		os.Exit(1)
 	}
 	return k


### PR DESCRIPTION
## Summary
When an org is configured with per-environment keys but `--env` is not specified (and no `default_env` is set), the error was misleading:

> `Error: no api_key found for org "sandbox"`

New error:

> `Error: org "sandbox" has per-environment keys (prod, staging) but no environment was specified.`
> `Use --env <name> or set default_env in \`syllable setup\`.`

## Test plan
- [ ] `syllable --org sandbox agents list` (sandbox has per-env keys, no default_env) shows the new error with available env names
- [ ] `syllable --org sandbox --env prod agents list` still works
- [ ] Org with a single top-level api_key still shows the original error

🤖 Generated with [Claude Code](https://claude.com/claude-code)