### PR TITLE
feat: add --include-test flag to sessions list

### DIFF
--- a/scripts/syllable-cli/cmd/sessions.go
+++ b/scripts/syllable-cli/cmd/sessions.go
@@ -52,6 +52,7 @@ func sessionsCmd() *cobra.Command {
 func sessionsListCmd() *cobra.Command {
 	var page, limit int
 	var search, searchField, startDate, endDate string
+	var includeTest bool
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -66,6 +67,9 @@ func sessionsListCmd() *cobra.Command {
 			}
 			if endDate != "" {
 				path += fmt.Sprintf("&end_datetime=%s", endDate)
+			}
+			if includeTest {
+				path += "&search_fields=is_test&search_field_values=true"
 			}
 
 			data, _, err := apiClient.Get(path)
@@ -129,6 +133,7 @@ func sessionsListCmd() *cobra.Command {
 	cmd.Flags().StringVar(&searchField, "search-field", "agent_name", "Field to search on (see API docs for valid values)")
 	cmd.Flags().StringVar(&startDate, "start-date", "", "Start datetime filter (e.g. 2024-01-01T00:00:00Z)")
 	cmd.Flags().StringVar(&endDate, "end-date", "", "End datetime filter")
+	cmd.Flags().BoolVar(&includeTest, "include-test", false, "Include test sessions (sessions on channel targets marked is_test=true, e.g. SIP test channels)")
 
 	return cmd
 }


### PR DESCRIPTION
## Summary

- Adds `--include-test` boolean flag to `syllable sessions list`
- By default, the API excludes sessions on channel targets with `is_test=true` (e.g. Direct SIP test channels), making those sessions invisible to list queries
- When `--include-test` is set, sends `search_fields=is_test&search_field_values=true` which causes the API to return all sessions regardless of test status
- Default behavior (flag omitted) is unchanged

**Note on API behavior:** Despite the parameter name `is_test=true`, the API treats this as "include test sessions" rather than a strict equality filter — it returns both test and non-test sessions when set. This is confirmed by testing.

## Test plan

- [ ] `syllable sessions list` (no flag) — returns only non-test sessions (existing behavior)
- [ ] `syllable sessions list --include-test` — returns all sessions including those on `is_test=true` channel targets (e.g. SIP channels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)