### PR TITLE
feat: add email to setup config and improve users me lookup

### DIFF
--- a/scripts/syllable-cli/cmd/setup.go
+++ b/scripts/syllable-cli/cmd/setup.go
@@ -24,6 +24,7 @@ import (
 type setupConfig struct {
 	DefaultOrg   string                `yaml:"default_org,omitempty"   json:"default_org"`
 	DefaultEnv   string                `yaml:"default_env,omitempty"   json:"default_env"`
+	Email        string                `yaml:"email,omitempty"         json:"email"`
 	Environments map[string]setupEnv   `yaml:"environments,omitempty"  json:"environments"`
 	Orgs         map[string]setupOrg   `yaml:"orgs,omitempty"          json:"orgs"`
 }
@@ -186,6 +187,7 @@ func setupMaskKeys(cfg *setupConfig) *setupConfig {
 	out := &setupConfig{
 		DefaultOrg:   cfg.DefaultOrg,
 		DefaultEnv:   cfg.DefaultEnv,
+		Email:        cfg.Email,
 		Environments: cfg.Environments,
 		Orgs:         map[string]setupOrg{},
 	}
@@ -352,6 +354,13 @@ input.input-warn:focus { border-color: var(--warn) !important; }
       <div class="field">
         <label>Default environment</label>
         <input id="default-env" type="text" placeholder="(none)" />
+      </div>
+    </div>
+    <div style="margin-top:12px">
+      <div class="field">
+        <label>Your email address</label>
+        <input id="user-email" type="email" placeholder="you@example.com" autocomplete="off" />
+        <div class="hint" style="margin-top:4px">Used by <code>syllable users me</code> to look up your account.</div>
       </div>
     </div>
   </section>
@@ -611,6 +620,7 @@ function renderDefaultOrgSelect() {
 function renderDefaults() {
   renderDefaultOrgSelect();
   document.getElementById('default-env').value = state.default_env || '';
+  document.getElementById('user-email').value = state.email || '';
 }
 
 function collectState() {
@@ -636,6 +646,7 @@ function save(exit) {
   collectState();
   state.default_org = document.getElementById('default-org').value;
   state.default_env = document.getElementById('default-env').value;
+  state.email = document.getElementById('user-email').value.trim();
 
   var errors = validate();
   if (errors.length > 0) { alert('Please fix the following before saving:\n\n' + errors.join('\n')); return; }
@@ -656,6 +667,7 @@ function save(exit) {
   var payload = {
     default_org: state.default_org,
     default_env: state.default_env,
+    email: state.email || '',
     environments: envsClean,
     orgs: orgsClean
   };

--- a/scripts/syllable-cli/cmd/users.go
+++ b/scripts/syllable-cli/cmd/users.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/asksyllable/syllable-cli/internal/output"
 )
 
@@ -302,6 +303,60 @@ func usersMeCmd() *cobra.Command {
 		Use:   "me",
 		Short: "Get the current authenticated user",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			email := viper.GetString("email")
+			if email != "" {
+				data, _, err := apiClient.Get("/api/v1/users/" + email)
+				if err != nil {
+					return err
+				}
+
+				if getOutputFmt() == "json" {
+					output.PrintJSON(data)
+					return nil
+				}
+
+				var u struct {
+					ID             json.Number `json:"id"`
+					Email          string      `json:"email"`
+					FirstName      *string     `json:"first_name"`
+					LastName       *string     `json:"last_name"`
+					RoleName       string      `json:"role_name"`
+					RoleID         json.Number `json:"role_id"`
+					ActivityStatus string      `json:"activity_status"`
+					LastUpdated    string      `json:"last_updated"`
+					LastSessionAt  string      `json:"last_session_at"`
+				}
+				if err := json.Unmarshal(data, &u); err != nil {
+					output.PrintJSON(data)
+					return nil
+				}
+
+				name := ""
+				if u.FirstName != nil {
+					name = *u.FirstName
+				}
+				if u.LastName != nil {
+					if name != "" {
+						name += " "
+					}
+					name += *u.LastName
+				}
+
+				rows := [][]string{
+					{"ID", u.ID.String()},
+					{"Email", u.Email},
+					{"Name", name},
+					{"Role", u.RoleName},
+					{"Status", u.ActivityStatus},
+					{"Last Updated", u.LastUpdated},
+					{"Last Session", u.LastSessionAt},
+				}
+				printTable([]string{"FIELD", "VALUE"}, rows)
+				return nil
+			}
+
+			// No email configured — fall back to listing users and taking the first result.
+			// Configure your email in `syllable setup` for a more accurate result.
 			data, _, err := apiClient.Get("/api/v1/users/?limit=1")
 			if err != nil {
 				return err
@@ -319,7 +374,6 @@ func usersMeCmd() *cobra.Command {
 					FirstName      *string     `json:"first_name"`
 					LastName       *string     `json:"last_name"`
 					RoleName       string      `json:"role_name"`
-					RoleID         json.Number `json:"role_id"`
 					ActivityStatus string      `json:"activity_status"`
 					LastUpdated    string      `json:"last_updated"`
 					LastSessionAt  string      `json:"last_session_at"`
@@ -331,22 +385,18 @@ func usersMeCmd() *cobra.Command {
 			}
 
 			u := result.Items[0]
-			firstName := ""
+			name := ""
 			if u.FirstName != nil {
-				firstName = *u.FirstName
+				name = *u.FirstName
 			}
-			lastName := ""
 			if u.LastName != nil {
-				lastName = *u.LastName
-			}
-			name := firstName
-			if lastName != "" {
 				if name != "" {
 					name += " "
 				}
-				name += lastName
+				name += *u.LastName
 			}
 
+			fmt.Fprintln(cmd.ErrOrStderr(), "Hint: configure your email in `syllable setup` for an exact lookup.")
 			rows := [][]string{
 				{"ID", u.ID.String()},
 				{"Email", u.Email},


### PR DESCRIPTION
## Summary

- Adds an optional `email` field to `~/.syllable/config.yaml`, configurable via `syllable setup` (new input in the Defaults section)
- `syllable users me` now uses the configured email to fetch the authenticated user directly via `GET /api/v1/users/<email>`, rather than pulling the first result from the users list
- Falls back to the previous list-based behavior when no email is configured, with a hint pointing to `syllable setup`

## Test plan

- [ ] Run `syllable setup`, add your email, save — verify `email` appears in `~/.syllable/config.yaml`
- [ ] Run `syllable users me` — verify it returns your user record directly
- [ ] Remove email from config, run `syllable users me` again — verify fallback behavior and hint message
- [ ] Run `syllable users me --output json` with email configured — verify JSON output

🤖 Generated with [Claude Code](https://claude.com/claude-code)