### PR TITLE
feat: add agents send-test-message command

### DIFF
--- a/scripts/syllable-cli/cmd/agents.go
+++ b/scripts/syllable-cli/cmd/agents.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -44,6 +45,7 @@ func agentsCmd() *cobra.Command {
 	cmd.AddCommand(agentsCreateCmd())
 	cmd.AddCommand(agentsUpdateCmd())
 	cmd.AddCommand(agentsDeleteCmd())
+	cmd.AddCommand(agentsSendTestMessageCmd())
 
 	return cmd
 }
@@ -266,4 +268,88 @@ func agentsDeleteCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func agentsSendTestMessageCmd() *cobra.Command {
+	var testID, text, serviceName, source string
+	var sessionStart bool
+	var timeout int
+
+	cmd := &cobra.Command{
+		Use:   "send-test-message <agent-id>",
+		Short: "Send a test message to an agent via the conversation test API",
+		Long: `Send a test message to an agent using the conversation test API.
+
+This calls POST /api/v1/agents/test/messages to exchange a single turn with
+the agent under test. Use --session-start on the first call to begin a new
+test session, then omit it for follow-up turns in the same session (reuse
+the same --test-id).`,
+		Example: `  # Start a new test session
+  syllable agents send-test-message 42 --test-id my-test-1 --session-start --text "Hi, I need help"
+
+  # Send a follow-up message in the same session
+  syllable agents send-test-message 42 --test-id my-test-1 --text "Yes, that's correct"
+
+  # Start a session with no caller text (agent speaks first)
+  syllable agents send-test-message 42 --test-id my-test-1 --session-start`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			agentID := args[0]
+
+			body := map[string]interface{}{
+				"agent_id":      agentID,
+				"test_id":       testID,
+				"service_name":  serviceName,
+				"source":        source,
+				"session_start": sessionStart,
+			}
+			if text != "" {
+				body["text"] = text
+			}
+
+			data, _, err := apiClient.PostWithTimeout(
+				"/api/v1/agents/test/messages",
+				body,
+				time.Duration(timeout)*time.Second,
+			)
+			if err != nil {
+				return err
+			}
+
+			if getOutputFmt() == "json" {
+				output.PrintJSON(data)
+				return nil
+			}
+
+			var resp struct {
+				TestID       string          `json:"test_id"`
+				AgentID      string          `json:"agent_id"`
+				ResponseText string          `json:"response_text"`
+				Text         string          `json:"text"`
+				Response     json.RawMessage `json:"response"`
+			}
+			if err := json.Unmarshal(data, &resp); err != nil {
+				output.PrintJSON(data)
+				return nil
+			}
+
+			rows := [][]string{
+				{"Test ID", resp.TestID},
+				{"Agent ID", resp.AgentID},
+				{"Response Text", resp.ResponseText},
+			}
+			printTable([]string{"FIELD", "VALUE"}, rows)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&testID, "test-id", "", "Test session identifier (required)")
+	cmd.Flags().StringVar(&text, "text", "", "Message text to send to the agent")
+	cmd.Flags().BoolVar(&sessionStart, "session-start", false, "Start a new test session")
+	cmd.Flags().StringVar(&serviceName, "service-name", "test", "Service name for the test")
+	cmd.Flags().StringVar(&source, "source", "tester@syllable.ai", "Source identifier for the test caller")
+	cmd.Flags().IntVar(&timeout, "timeout", 90, "Request timeout in seconds")
+	cmd.MarkFlagRequired("test-id")
+
+	return cmd
 }

--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -102,7 +102,7 @@ func TestRootCommandHasSubcommands(t *testing.T) {
 
 func TestAgentsCommandHasSubcommands(t *testing.T) {
 	cmd := agentsCmd()
-	expected := []string{"list", "get", "create", "update", "delete"}
+	expected := []string{"list", "get", "create", "update", "delete", "send-test-message"}
 	subs := make(map[string]bool)
 	for _, c := range cmd.Commands() {
 		subs[c.Name()] = true
@@ -394,6 +394,146 @@ func TestAgentsDelete(t *testing.T) {
 	}
 	if path != "/api/v1/agents/42" {
 		t.Errorf("expected path /api/v1/agents/42, got %s", path)
+	}
+}
+
+// --- Agents send-test-message tests ---
+
+func TestAgentsSendTestMessage(t *testing.T) {
+	var method, requestPath string
+	var receivedBody map[string]interface{}
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		requestPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedBody)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"test_id":       "test-123",
+			"agent_id":      "42",
+			"response_text": "Hello, how can I help you?",
+			"text":          "Hi there",
+			"response":      map[string]interface{}{"content": map[string]interface{}{"session_id": "sess-1"}},
+		})
+	})
+	defer server.Close()
+
+	cmd := agentsSendTestMessageCmd()
+	cmd.SetArgs([]string{"42", "--test-id", "test-123", "--session-start", "--text", "Hi there"})
+	out := captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if method != "POST" {
+		t.Errorf("expected POST method, got %s", method)
+	}
+	if requestPath != "/api/v1/agents/test/messages" {
+		t.Errorf("unexpected request path: %s", requestPath)
+	}
+	if receivedBody["agent_id"] != "42" {
+		t.Errorf("expected agent_id=42, got %v", receivedBody["agent_id"])
+	}
+	if receivedBody["test_id"] != "test-123" {
+		t.Errorf("expected test_id=test-123, got %v", receivedBody["test_id"])
+	}
+	if receivedBody["session_start"] != true {
+		t.Errorf("expected session_start=true, got %v", receivedBody["session_start"])
+	}
+	if receivedBody["text"] != "Hi there" {
+		t.Errorf("expected text='Hi there', got %v", receivedBody["text"])
+	}
+	if receivedBody["service_name"] != "test" {
+		t.Errorf("expected service_name=test, got %v", receivedBody["service_name"])
+	}
+	if receivedBody["source"] != "tester@syllable.ai" {
+		t.Errorf("expected source=tester@syllable.ai, got %v", receivedBody["source"])
+	}
+	if !strings.Contains(out, "test-123") {
+		t.Errorf("output should contain test_id, got: %s", out)
+	}
+}
+
+func TestAgentsSendTestMessageJSONOutput(t *testing.T) {
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"test_id":       "test-456",
+			"agent_id":      "10",
+			"response_text": "Welcome!",
+			"response":      map[string]interface{}{"content": map[string]interface{}{"session_id": "sess-2", "action": "none"}},
+		})
+	})
+	defer server.Close()
+
+	cmd := agentsSendTestMessageCmd()
+	cmd.SetArgs([]string{"10", "--test-id", "test-456", "--session-start"})
+	out := captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// setupTestServer sets output to json
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("expected valid JSON output, got: %s", out)
+	}
+	if parsed["test_id"] != "test-456" {
+		t.Errorf("expected test_id=test-456 in JSON output, got %v", parsed["test_id"])
+	}
+	resp, ok := parsed["response"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected response object in JSON output")
+	}
+	content, ok := resp["content"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected response.content object in JSON output")
+	}
+	if content["session_id"] != "sess-2" {
+		t.Errorf("expected session_id=sess-2, got %v", content["session_id"])
+	}
+}
+
+func TestAgentsSendTestMessageRequiresTestID(t *testing.T) {
+	cmd := agentsSendTestMessageCmd()
+	cmd.SetArgs([]string{"42"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("expected error when --test-id is missing")
+	}
+}
+
+func TestAgentsSendTestMessageRequiresAgentID(t *testing.T) {
+	cmd := agentsSendTestMessageCmd()
+	cmd.SetArgs([]string{"--test-id", "test-1"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("expected error when agent-id argument is missing")
+	}
+}
+
+func TestAgentsSendTestMessageNoTextOmitsField(t *testing.T) {
+	var receivedBody map[string]interface{}
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedBody)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"test_id":  "test-789",
+			"agent_id": "5",
+		})
+	})
+	defer server.Close()
+
+	cmd := agentsSendTestMessageCmd()
+	cmd.SetArgs([]string{"5", "--test-id", "test-789", "--session-start"})
+	captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if _, exists := receivedBody["text"]; exists {
+		t.Errorf("text field should be omitted when --text is not provided, got %v", receivedBody["text"])
 	}
 }
 

--- a/scripts/syllable-cli/internal/client/client.go
+++ b/scripts/syllable-cli/internal/client/client.go
@@ -174,6 +174,14 @@ func (c *Client) DeleteWithBody(path string, body interface{}) ([]byte, int, err
 	return c.Do(http.MethodDelete, path, body)
 }
 
+// PostWithTimeout performs a POST request with a custom timeout (overrides the default 30s).
+func (c *Client) PostWithTimeout(path string, body interface{}, timeout time.Duration) ([]byte, int, error) {
+	orig := c.HTTPClient.Timeout
+	c.HTTPClient.Timeout = timeout
+	defer func() { c.HTTPClient.Timeout = orig }()
+	return c.Do(http.MethodPost, path, body)
+}
+
 // PostMultipart performs a multipart/form-data POST, uploading a local file as the named field.
 // Large files may require more than the default 30s client timeout — callers should be aware.
 func (c *Client) PostMultipart(path, fieldName, filePath string) ([]byte, int, error) {


### PR DESCRIPTION
## Summary
- Adds `syllable agents send-test-message <agent-id>` command wrapping `POST /api/v1/agents/test/messages`
- Adds `PostWithTimeout` method to the HTTP client for requests that need longer than the default 30s (test messages default to 90s due to slow tool calls)
- Replaces the Python `test-api-helper.py` script used by the prompt-tester skill with a native CLI command

## Flags
| Flag | Default | Description |
|------|---------|-------------|
| `--test-id` | (required) | Test session identifier |
| `--text` | (omitted) | Message text to send |
| `--session-start` | `false` | Start a new test session |
| `--service-name` | `test` | Service name |
| `--source` | `tester@syllable.ai` | Source identifier |
| `--timeout` | `90` | Request timeout in seconds |

## Test plan
- [x] 5 new tests added covering happy path, JSON output, required flags, and text omission
- [x] All existing tests pass (`go test ./...`)
- [x] `--help` output verified
- [ ] Manual test against a live agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)