### PR TITLE
fix: default text to "" on send-test-message --session-start

### DIFF
--- a/scripts/syllable-cli/cmd/agents.go
+++ b/scripts/syllable-cli/cmd/agents.go
@@ -305,6 +305,8 @@ the same --test-id).`,
 			}
 			if cmd.Flags().Changed("text") {
 				body["text"] = text
+			} else if sessionStart {
+				body["text"] = ""
 			}
 
 			data, _, err := apiClient.PostWithTimeout(

--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -525,7 +525,7 @@ func TestAgentsSendTestMessageNoTextOmitsField(t *testing.T) {
 	defer server.Close()
 
 	cmd := agentsSendTestMessageCmd()
-	cmd.SetArgs([]string{"5", "--test-id", "test-789", "--session-start"})
+	cmd.SetArgs([]string{"5", "--test-id", "test-789"})
 	captureStdout(func() {
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -533,7 +533,36 @@ func TestAgentsSendTestMessageNoTextOmitsField(t *testing.T) {
 	})
 
 	if _, exists := receivedBody["text"]; exists {
-		t.Errorf("text field should be omitted when --text is not provided, got %v", receivedBody["text"])
+		t.Errorf("text field should be omitted on follow-up turns when --text is not provided, got %v", receivedBody["text"])
+	}
+}
+
+func TestAgentsSendTestMessageSessionStartNoTextSendsEmpty(t *testing.T) {
+	var receivedBody map[string]interface{}
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedBody)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"test_id":  "test-greet",
+			"agent_id": "5",
+		})
+	})
+	defer server.Close()
+
+	cmd := agentsSendTestMessageCmd()
+	cmd.SetArgs([]string{"5", "--test-id", "test-greet", "--session-start"})
+	captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	val, exists := receivedBody["text"]
+	if !exists {
+		t.Fatal("text field should be present (as empty string) when --session-start is set without --text")
+	}
+	if val != "" {
+		t.Errorf("expected text='' on session start without --text, got %v", val)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix `agents send-test-message --session-start` (without `--text`) returning HTTP 500. The request now sends `text: ""` so the conversation test API accepts it.
- Preserves the absent-vs-empty distinction from #46 for follow-up turns: silence in mid-session still requires explicit `--text ""`.
- Updates tests so `NoTextOmitsField` covers the follow-up-turn path, and adds `SessionStartNoTextSendsEmpty` for the new default.

The third help example (`# Start a session with no caller text (agent speaks first)`) now works as printed — no help-text change needed.

Fixes #50

## Test plan

- [x] `go test ./...` passes (full repo).
- [x] `TestAgentsSendTestMessageNoTextOmitsField` — follow-up turn (no `--session-start`, no `--text`) still omits `text`.
- [x] `TestAgentsSendTestMessageSessionStartNoTextSendsEmpty` — new test asserting `text: ""` is sent on `--session-start` without `--text`.
- [x] `TestAgentsSendTestMessageEmptyTextSendsField` — explicit `--text ""` continues to send `text: ""`.
- [ ] Smoke test against sandbox: `syllable --org sandbox agents send-test-message <id> --test-id smoke-$(date +%s) --session-start` should now return 200 with a greeting in `response_text`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)