### PR TITLE
feat: add bulk upload/download commands for directory and outbound batches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,6 +342,7 @@ syllable outbound batches delete <batch-id>
 syllable outbound batches results <batch-id>
 syllable outbound batches requests <batch-id> --file requests.json
 syllable outbound batches remove-requests <batch-id> --file requests.json
+syllable outbound batches upload <batch-id> --file contacts.csv
 
 # Campaigns
 syllable outbound campaigns list [--page N] [--limit N] [--search TEXT]
@@ -374,6 +375,8 @@ syllable directory create --file member.json
 syllable directory create --name NAME --type TYPE
 syllable directory update <member-id> --file member.json
 syllable directory delete <member-id>
+syllable directory upload --file members.csv
+syllable directory download [--format normalized|raw]
 ```
 
 ### Insights

--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -1187,6 +1187,157 @@ func TestOutboundBatchesResults(t *testing.T) {
 	}
 }
 
+func TestDirectoryUpload(t *testing.T) {
+	tmp, err := os.CreateTemp("", "members-*.csv")
+	if err != nil {
+		t.Fatalf("creating temp file: %v", err)
+	}
+	defer os.Remove(tmp.Name())
+	tmp.WriteString("name,type\nAlice,user\n")
+	tmp.Close()
+
+	var method, path, contentType string
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		path = r.URL.Path
+		contentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	})
+	defer server.Close()
+
+	cmd := directoryUploadCmd()
+	cmd.SetArgs([]string{"--file", tmp.Name()})
+	captureStdout(func() {
+		cmd.Execute()
+	})
+
+	if method != "PUT" {
+		t.Errorf("expected PUT method, got %s", method)
+	}
+	if path != "/api/v1/directory_members/upload/" {
+		t.Errorf("unexpected path: %s", path)
+	}
+	if !strings.HasPrefix(contentType, "multipart/form-data") {
+		t.Errorf("expected multipart/form-data, got %s", contentType)
+	}
+}
+
+func TestDirectoryUploadStdin(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("creating pipe: %v", err)
+	}
+	go func() {
+		w.WriteString("name,type\nAlice,user\n")
+		w.Close()
+	}()
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	var method, path, body string
+	server := setupTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+		method = req.Method
+		path = req.URL.Path
+		buf, _ := io.ReadAll(req.Body)
+		body = string(buf)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	})
+	defer server.Close()
+
+	cmd := directoryUploadCmd()
+	cmd.SetArgs([]string{"--file", "-"})
+	captureStdout(func() {
+		cmd.Execute()
+	})
+
+	if method != "PUT" {
+		t.Errorf("expected PUT method, got %s", method)
+	}
+	if path != "/api/v1/directory_members/upload/" {
+		t.Errorf("unexpected path: %s", path)
+	}
+	if !strings.Contains(body, "Alice,user") {
+		t.Errorf("expected stdin contents in multipart body, got: %s", body)
+	}
+}
+
+func TestDirectoryDownload(t *testing.T) {
+	var method, path, query string
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		path = r.URL.Path
+		query = r.URL.RawQuery
+		w.Write([]byte("name,type\n"))
+	})
+	defer server.Close()
+
+	// default --format normalized
+	cmd := directoryDownloadCmd()
+	cmd.SetArgs([]string{})
+	captureStdout(func() {
+		cmd.Execute()
+	})
+
+	if method != "GET" {
+		t.Errorf("expected GET method, got %s", method)
+	}
+	if path != "/api/v1/directory_members/download/" {
+		t.Errorf("unexpected path: %s", path)
+	}
+	if query != "response_format=normalized" {
+		t.Errorf("unexpected default query: %s", query)
+	}
+
+	// --format raw
+	cmd = directoryDownloadCmd()
+	cmd.SetArgs([]string{"--format", "raw"})
+	captureStdout(func() {
+		cmd.Execute()
+	})
+	if query != "response_format=raw" {
+		t.Errorf("expected raw query, got %s", query)
+	}
+}
+
+func TestOutboundBatchesUpload(t *testing.T) {
+	tmp, err := os.CreateTemp("", "contacts-*.csv")
+	if err != nil {
+		t.Fatalf("creating temp file: %v", err)
+	}
+	defer os.Remove(tmp.Name())
+	tmp.WriteString("phone\n+15551234567\n")
+	tmp.Close()
+
+	var method, path, contentType string
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		path = r.URL.Path
+		contentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	})
+	defer server.Close()
+
+	cmd := outboundBatchesUploadCmd()
+	cmd.SetArgs([]string{"batch-1", "--file", tmp.Name()})
+	captureStdout(func() {
+		cmd.Execute()
+	})
+
+	if method != "POST" {
+		t.Errorf("expected POST method, got %s", method)
+	}
+	if path != "/api/v1/outbound/batches/batch-1/upload_batch" {
+		t.Errorf("unexpected path: %s", path)
+	}
+	if !strings.HasPrefix(contentType, "multipart/form-data") {
+		t.Errorf("expected multipart/form-data, got %s", contentType)
+	}
+}
+
 func TestInsightsWorkflowsDelete(t *testing.T) {
 	var method, path string
 	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -1264,6 +1264,49 @@ func TestDirectoryUploadStdin(t *testing.T) {
 	}
 }
 
+func TestInsightsFoldersUploadFileStdin(t *testing.T) {
+	// Locks in the side-benefit fix: doMultipart now honors --file - on every
+	// caller, including the long-broken insights folders upload-file command.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("creating pipe: %v", err)
+	}
+	go func() {
+		w.WriteString("audio-bytes")
+		w.Close()
+	}()
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	var method, path, body string
+	server := setupTestServer(t, func(w http.ResponseWriter, req *http.Request) {
+		method = req.Method
+		path = req.URL.Path
+		buf, _ := io.ReadAll(req.Body)
+		body = string(buf)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{}"))
+	})
+	defer server.Close()
+
+	cmd := insightsFoldersUploadFileCmd()
+	cmd.SetArgs([]string{"folder-1", "--file", "-", "--call-id", "call-1"})
+	captureStdout(func() {
+		cmd.Execute()
+	})
+
+	if method != "POST" {
+		t.Errorf("expected POST method, got %s", method)
+	}
+	if path != "/api/v1/insights/folders/folder-1/upload-file" {
+		t.Errorf("unexpected path: %s", path)
+	}
+	if !strings.Contains(body, "audio-bytes") {
+		t.Errorf("expected stdin contents in multipart body, got: %s", body)
+	}
+}
+
 func TestDirectoryDownload(t *testing.T) {
 	var method, path, query string
 	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/scripts/syllable-cli/cmd/directory.go
+++ b/scripts/syllable-cli/cmd/directory.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -297,7 +298,7 @@ func directoryDownloadCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Print(string(data))
+			os.Stdout.Write(data)
 			return nil
 		},
 	}

--- a/scripts/syllable-cli/cmd/directory.go
+++ b/scripts/syllable-cli/cmd/directory.go
@@ -30,7 +30,13 @@ func directoryCmd() *cobra.Command {
   syllable directory update 12 --file member.json
 
   # Delete a directory member
-  syllable directory delete 12`,
+  syllable directory delete 12
+
+  # Bulk-import directory members from a CSV
+  syllable directory upload --file members.csv
+
+  # Export all directory members as CSV
+  syllable directory download > members.csv`,
 	}
 
 	cmd.AddCommand(directoryListCmd())
@@ -38,6 +44,8 @@ func directoryCmd() *cobra.Command {
 	cmd.AddCommand(directoryCreateCmd())
 	cmd.AddCommand(directoryUpdateCmd())
 	cmd.AddCommand(directoryDeleteCmd())
+	cmd.AddCommand(directoryUploadCmd())
+	cmd.AddCommand(directoryDownloadCmd())
 
 	return cmd
 }
@@ -249,4 +257,51 @@ func directoryDeleteCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func directoryUploadCmd() *cobra.Command {
+	var file string
+
+	cmd := &cobra.Command{
+		Use:   "upload",
+		Short: "Bulk-import directory members from a file",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if file == "" {
+				return fmt.Errorf("required flag: --file")
+			}
+			data, _, err := apiClient.PutMultipart("/api/v1/directory_members/upload/", "file", file)
+			if err != nil {
+				return err
+			}
+			output.PrintJSON(data)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&file, "file", "", "Path to local file to upload")
+	return cmd
+}
+
+func directoryDownloadCmd() *cobra.Command {
+	var format string
+
+	cmd := &cobra.Command{
+		Use:   "download",
+		Short: "Bulk-export directory members",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if format != "normalized" && format != "raw" {
+				return fmt.Errorf("--format must be 'normalized' or 'raw' (got %q)", format)
+			}
+			path := "/api/v1/directory_members/download/?response_format=" + format
+			data, _, err := apiClient.Get(path)
+			if err != nil {
+				return err
+			}
+			fmt.Print(string(data))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&format, "format", "normalized", "Response format: normalized or raw")
+	return cmd
 }

--- a/scripts/syllable-cli/cmd/outbound.go
+++ b/scripts/syllable-cli/cmd/outbound.go
@@ -31,6 +31,9 @@ func outboundCmd() *cobra.Command {
   # Remove requests from a batch
   syllable outbound batches remove-requests abc-123 --file request-ids.json
 
+  # Bulk-upload contacts into a batch from a CSV
+  syllable outbound batches upload abc-123 --file contacts.csv
+
   # List all outbound campaigns
   syllable outbound campaigns list
 
@@ -60,6 +63,7 @@ func outboundBatchesCmd() *cobra.Command {
 	cmd.AddCommand(outboundBatchesResultsCmd())
 	cmd.AddCommand(outboundBatchesRequestsCmd())
 	cmd.AddCommand(outboundBatchesRemoveRequestsCmd())
+	cmd.AddCommand(outboundBatchesUploadCmd())
 
 	return cmd
 }
@@ -379,6 +383,31 @@ func outboundBatchesRemoveRequestsCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&file, "file", "", "Path to JSON body file")
+	return cmd
+}
+
+func outboundBatchesUploadCmd() *cobra.Command {
+	var file string
+
+	cmd := &cobra.Command{
+		Use:   "upload <batch-id>",
+		Short: "Bulk-upload contacts into an outbound batch",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if file == "" {
+				return fmt.Errorf("required flag: --file")
+			}
+			path := fmt.Sprintf("/api/v1/outbound/batches/%s/upload_batch", args[0])
+			data, _, err := apiClient.PostMultipart(path, "file", file)
+			if err != nil {
+				return err
+			}
+			output.PrintJSON(data)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&file, "file", "", "Path to local file to upload")
 	return cmd
 }
 

--- a/scripts/syllable-cli/internal/client/client.go
+++ b/scripts/syllable-cli/internal/client/client.go
@@ -187,38 +187,56 @@ func (c *Client) PostWithTimeout(path string, body interface{}, timeout time.Dur
 // PostMultipart performs a multipart/form-data POST, uploading a local file as the named field.
 // Large files may require more than the default 30s client timeout — callers should be aware.
 func (c *Client) PostMultipart(path, fieldName, filePath string) ([]byte, int, error) {
-	f, err := os.Open(filePath)
-	if err != nil {
-		return nil, 0, fmt.Errorf("opening file: %w", err)
+	return c.doMultipart(http.MethodPost, path, fieldName, filePath)
+}
+
+// PutMultipart performs a multipart/form-data PUT, uploading a local file as the named field.
+func (c *Client) PutMultipart(path, fieldName, filePath string) ([]byte, int, error) {
+	return c.doMultipart(http.MethodPut, path, fieldName, filePath)
+}
+
+func (c *Client) doMultipart(method, path, fieldName, filePath string) ([]byte, int, error) {
+	var src io.Reader
+	var formName string
+	if filePath == "-" {
+		src = os.Stdin
+		formName = "stdin"
+	} else {
+		f, err := os.Open(filePath)
+		if err != nil {
+			return nil, 0, fmt.Errorf("opening file: %w", err)
+		}
+		defer f.Close()
+		src = f
+		formName = filepath.Base(filePath)
 	}
-	defer f.Close()
 
 	var buf bytes.Buffer
 	w := multipart.NewWriter(&buf)
 
-	part, err := w.CreateFormFile(fieldName, filepath.Base(filePath))
+	part, err := w.CreateFormFile(fieldName, formName)
 	if err != nil {
 		return nil, 0, fmt.Errorf("creating form file: %w", err)
 	}
-	if _, err := io.Copy(part, f); err != nil {
+	if _, err := io.Copy(part, src); err != nil {
 		return nil, 0, fmt.Errorf("copying file to form: %w", err)
 	}
 	w.Close()
 
 	if c.DryRun {
 		out := map[string]interface{}{
-			"dry_run":     true,
-			"method":      http.MethodPost,
-			"url":         c.BaseURL + path,
-			"field":       fieldName,
-			"file":        filePath,
+			"dry_run":      true,
+			"method":       method,
+			"url":          c.BaseURL + path,
+			"field":        fieldName,
+			"file":         filePath,
 			"content_type": w.FormDataContentType(),
 		}
 		data, _ := json.Marshal(out)
 		return nil, 0, &DryRunResult{Output: data}
 	}
 
-	req, err := http.NewRequest(http.MethodPost, c.BaseURL+path, &buf)
+	req, err := http.NewRequest(method, c.BaseURL+path, &buf)
 	if err != nil {
 		return nil, 0, fmt.Errorf("creating request: %w", err)
 	}
@@ -227,7 +245,7 @@ func (c *Client) PostMultipart(path, fieldName, filePath string) ([]byte, int, e
 	req.Header.Set("Accept", "application/json")
 
 	if c.Verbose {
-		fmt.Fprintf(os.Stderr, "> %s %s\n", http.MethodPost, c.BaseURL+path)
+		fmt.Fprintf(os.Stderr, "> %s %s\n", method, c.BaseURL+path)
 		fmt.Fprintf(os.Stderr, "> Syllable-API-Key: %s\n", maskKey(c.APIKey))
 		fmt.Fprintf(os.Stderr, "> Content-Type: %s\n", w.FormDataContentType())
 		fmt.Fprintf(os.Stderr, "> (multipart file: %s, field: %s)\n\n", filePath, fieldName)

--- a/scripts/syllable-cli/internal/spec/spec_test.go
+++ b/scripts/syllable-cli/internal/spec/spec_test.go
@@ -50,3 +50,23 @@ func TestOpenAPIHasPaths(t *testing.T) {
 		t.Fatal("OpenAPI spec has no paths")
 	}
 }
+
+// TestBulkOperationPathsMatch guards the exact paths used by the bulk CLI
+// commands against silent spec drift — slash-mismatch redirects drop the
+// Syllable-API-Key header on some clients, so trailing slashes must match.
+func TestBulkOperationPathsMatch(t *testing.T) {
+	var parsed map[string]interface{}
+	json.Unmarshal(OpenAPI, &parsed)
+	paths := parsed["paths"].(map[string]interface{})
+
+	want := []string{
+		"/api/v1/directory_members/upload/",
+		"/api/v1/directory_members/download/",
+		"/api/v1/outbound/batches/{batch_id}/upload_batch",
+	}
+	for _, p := range want {
+		if _, ok := paths[p]; !ok {
+			t.Errorf("bulk operation path %q missing from spec — CLI command will hit a slash-mismatch redirect", p)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds three previously-missing bulk operations from the embedded OpenAPI spec to the CLI: `syllable directory upload --file <path>` (PUT multipart), `syllable directory download [--format normalized|raw]`, and `syllable outbound batches upload <batch-id> --file <path>` (POST multipart).
- Refactors the multipart helper into a shared `doMultipart` and adds `PutMultipart` (the directory bulk-load endpoint is PUT, no PUT-multipart helper existed).
- The shared helper now honors `--file -` by streaming `os.Stdin`, which also fixes the same documented-but-broken behavior in the existing `insights folders upload-file` command.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` all packages pass
- [x] New tests pass: `TestDirectoryUpload`, `TestDirectoryUploadStdin`, `TestDirectoryDownload`, `TestOutboundBatchesUpload`
- [x] Help text renders for all three new commands
- [ ] Live smoke test against a dev/sandbox org of your choosing — recommended round-trip: `syllable directory upload --file members.csv` → `syllable directory download > out.csv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)