### PR TITLE
feat: add directory history, restore, and test commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -377,9 +377,9 @@ syllable directory update <member-id> --file member.json
 syllable directory delete <member-id>
 syllable directory upload --file members.csv
 syllable directory download [--format normalized|raw]
-syllable directory history <member-id>
-syllable directory restore <member-id>
-syllable directory test <member-id>
+syllable directory history <member-id> [--page N] [--limit N] [--order-by-direction asc|desc]
+syllable directory restore <member-id> [--comments TEXT]
+syllable directory test <member-id> [--timestamp ISO8601] [--language-code BCP47]
 ```
 
 ### Insights

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -377,6 +377,9 @@ syllable directory update <member-id> --file member.json
 syllable directory delete <member-id>
 syllable directory upload --file members.csv
 syllable directory download [--format normalized|raw]
+syllable directory history <member-id>
+syllable directory restore <member-id>
+syllable directory test <member-id>
 ```
 
 ### Insights

--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -1346,10 +1346,11 @@ func TestDirectoryDownload(t *testing.T) {
 }
 
 func TestDirectoryHistory(t *testing.T) {
-	var method, requestPath string
+	var method, requestPath, query string
 	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		method = r.Method
 		requestPath = r.URL.Path
+		query = r.URL.RawQuery
 		json.NewEncoder(w).Encode([]interface{}{})
 	})
 	defer server.Close()
@@ -1366,13 +1367,45 @@ func TestDirectoryHistory(t *testing.T) {
 	if requestPath != "/api/v1/directory_members/42/history" {
 		t.Errorf("unexpected request path: %s", requestPath)
 	}
+	if !strings.Contains(query, "page=0") || !strings.Contains(query, "limit=25") {
+		t.Errorf("expected page+limit defaults in query, got: %s", query)
+	}
+}
+
+func TestDirectoryHistoryWithFlags(t *testing.T) {
+	var query string
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		query = r.URL.RawQuery
+		json.NewEncoder(w).Encode([]interface{}{})
+	})
+	defer server.Close()
+
+	cmd := directoryHistoryCmd()
+	cmd.SetArgs([]string{"42", "--page", "2", "--limit", "10", "--order-by-direction", "desc"})
+	captureStdout(func() {
+		cmd.Execute()
+	})
+
+	if !strings.Contains(query, "page=2") {
+		t.Errorf("expected page=2, got: %s", query)
+	}
+	if !strings.Contains(query, "limit=10") {
+		t.Errorf("expected limit=10, got: %s", query)
+	}
+	if !strings.Contains(query, "order_by_direction=desc") {
+		t.Errorf("expected order_by_direction=desc, got: %s", query)
+	}
 }
 
 func TestDirectoryRestore(t *testing.T) {
-	var method, requestPath string
+	var method, requestPath, contentType string
+	var receivedBody map[string]interface{}
 	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		method = r.Method
 		requestPath = r.URL.Path
+		contentType = r.Header.Get("Content-Type")
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedBody)
 		w.WriteHeader(http.StatusNoContent)
 	})
 	defer server.Close()
@@ -1389,19 +1422,46 @@ func TestDirectoryRestore(t *testing.T) {
 	if requestPath != "/api/v1/directory_members/42/restore" {
 		t.Errorf("unexpected request path: %s", requestPath)
 	}
+	if contentType != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", contentType)
+	}
+	if receivedBody == nil {
+		t.Error("expected JSON object body, got nil")
+	}
+}
+
+func TestDirectoryRestoreWithComments(t *testing.T) {
+	var receivedBody map[string]interface{}
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedBody)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	defer server.Close()
+
+	cmd := directoryRestoreCmd()
+	cmd.SetArgs([]string{"42", "--comments", "Brought back by request"})
+	captureStdout(func() {
+		cmd.Execute()
+	})
+
+	if receivedBody["comments"] != "Brought back by request" {
+		t.Errorf("expected comments in body, got %v", receivedBody["comments"])
+	}
 }
 
 func TestDirectoryTest(t *testing.T) {
-	var method, requestPath string
+	var method, requestPath, query string
 	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		method = r.Method
 		requestPath = r.URL.Path
+		query = r.URL.RawQuery
 		json.NewEncoder(w).Encode(map[string]interface{}{"extension": "1234"})
 	})
 	defer server.Close()
 
 	cmd := directoryTestCmd()
-	cmd.SetArgs([]string{"42"})
+	cmd.SetArgs([]string{"42", "--timestamp", "2025-12-04T14:29:39Z"})
 	captureStdout(func() {
 		cmd.Execute()
 	})
@@ -1411,6 +1471,47 @@ func TestDirectoryTest(t *testing.T) {
 	}
 	if requestPath != "/api/v1/directory_members/42/test" {
 		t.Errorf("unexpected request path: %s", requestPath)
+	}
+	if !strings.Contains(query, "timestamp=2025-12-04T14%3A29%3A39Z") {
+		t.Errorf("expected URL-encoded timestamp in query, got: %s", query)
+	}
+}
+
+func TestDirectoryTestDefaultsTimestampToNow(t *testing.T) {
+	var query string
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		query = r.URL.RawQuery
+		w.Write([]byte(`{}`))
+	})
+	defer server.Close()
+
+	cmd := directoryTestCmd()
+	cmd.SetArgs([]string{"42"})
+	captureStdout(func() {
+		cmd.Execute()
+	})
+
+	if !strings.Contains(query, "timestamp=") {
+		t.Errorf("expected timestamp query param even without --timestamp, got: %s", query)
+	}
+}
+
+func TestDirectoryTestWithLanguageCode(t *testing.T) {
+	var query string
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		query = r.URL.RawQuery
+		w.Write([]byte(`{}`))
+	})
+	defer server.Close()
+
+	cmd := directoryTestCmd()
+	cmd.SetArgs([]string{"42", "--timestamp", "2025-01-01T00:00:00Z", "--language-code", "es-MX"})
+	captureStdout(func() {
+		cmd.Execute()
+	})
+
+	if !strings.Contains(query, "language_code=es-MX") {
+		t.Errorf("expected language_code=es-MX in query, got: %s", query)
 	}
 }
 

--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -1345,6 +1345,75 @@ func TestDirectoryDownload(t *testing.T) {
 	}
 }
 
+func TestDirectoryHistory(t *testing.T) {
+	var method, requestPath string
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		requestPath = r.URL.Path
+		json.NewEncoder(w).Encode([]interface{}{})
+	})
+	defer server.Close()
+
+	cmd := directoryHistoryCmd()
+	cmd.SetArgs([]string{"42"})
+	captureStdout(func() {
+		cmd.Execute()
+	})
+
+	if method != "GET" {
+		t.Errorf("expected GET method, got %s", method)
+	}
+	if requestPath != "/api/v1/directory_members/42/history" {
+		t.Errorf("unexpected request path: %s", requestPath)
+	}
+}
+
+func TestDirectoryRestore(t *testing.T) {
+	var method, requestPath string
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		requestPath = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	})
+	defer server.Close()
+
+	cmd := directoryRestoreCmd()
+	cmd.SetArgs([]string{"42"})
+	captureStdout(func() {
+		cmd.Execute()
+	})
+
+	if method != "PUT" {
+		t.Errorf("expected PUT method, got %s", method)
+	}
+	if requestPath != "/api/v1/directory_members/42/restore" {
+		t.Errorf("unexpected request path: %s", requestPath)
+	}
+}
+
+func TestDirectoryTest(t *testing.T) {
+	var method, requestPath string
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		requestPath = r.URL.Path
+		json.NewEncoder(w).Encode(map[string]interface{}{"extension": "1234"})
+	})
+	defer server.Close()
+
+	cmd := directoryTestCmd()
+	cmd.SetArgs([]string{"42"})
+	captureStdout(func() {
+		cmd.Execute()
+	})
+
+	if method != "GET" {
+		t.Errorf("expected GET method, got %s", method)
+	}
+	if requestPath != "/api/v1/directory_members/42/test" {
+		t.Errorf("unexpected request path: %s", requestPath)
+	}
+}
+
 func TestOutboundBatchesUpload(t *testing.T) {
 	tmp, err := os.CreateTemp("", "contacts-*.csv")
 	if err != nil {

--- a/scripts/syllable-cli/cmd/directory.go
+++ b/scripts/syllable-cli/cmd/directory.go
@@ -37,7 +37,16 @@ func directoryCmd() *cobra.Command {
   syllable directory upload --file members.csv
 
   # Export all directory members as CSV
-  syllable directory download > members.csv`,
+  syllable directory download > members.csv
+
+  # Show version history for a directory member
+  syllable directory history 12
+
+  # Restore a soft-deleted directory member
+  syllable directory restore 12
+
+  # Test extension lookup for a directory member
+  syllable directory test 12`,
 	}
 
 	cmd.AddCommand(directoryListCmd())
@@ -47,6 +56,9 @@ func directoryCmd() *cobra.Command {
 	cmd.AddCommand(directoryDeleteCmd())
 	cmd.AddCommand(directoryUploadCmd())
 	cmd.AddCommand(directoryDownloadCmd())
+	cmd.AddCommand(directoryHistoryCmd())
+	cmd.AddCommand(directoryRestoreCmd())
+	cmd.AddCommand(directoryTestCmd())
 
 	return cmd
 }
@@ -305,4 +317,56 @@ func directoryDownloadCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&format, "format", "normalized", "Response format: normalized or raw")
 	return cmd
+}
+
+func directoryHistoryCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "history <member-id>",
+		Short: "Show version history for a directory member",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, _, err := apiClient.Get("/api/v1/directory_members/" + args[0] + "/history")
+			if err != nil {
+				return err
+			}
+			output.PrintJSON(data)
+			return nil
+		},
+	}
+}
+
+func directoryRestoreCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "restore <member-id>",
+		Short: "Restore a soft-deleted directory member",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, _, err := apiClient.Put("/api/v1/directory_members/"+args[0]+"/restore", nil)
+			if err != nil {
+				return err
+			}
+			if len(data) > 0 {
+				output.PrintJSON(data)
+			} else {
+				fmt.Printf("Directory member %s restored.\n", args[0])
+			}
+			return nil
+		},
+	}
+}
+
+func directoryTestCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "test <member-id>",
+		Short: "Test extension lookup for a directory member",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, _, err := apiClient.Get("/api/v1/directory_members/" + args[0] + "/test")
+			if err != nil {
+				return err
+			}
+			output.PrintJSON(data)
+			return nil
+		},
+	}
 }

--- a/scripts/syllable-cli/cmd/directory.go
+++ b/scripts/syllable-cli/cmd/directory.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -320,12 +321,22 @@ func directoryDownloadCmd() *cobra.Command {
 }
 
 func directoryHistoryCmd() *cobra.Command {
-	return &cobra.Command{
+	var page, limit int
+	var orderByDirection, responseFormat string
+
+	cmd := &cobra.Command{
 		Use:   "history <member-id>",
 		Short: "Show version history for a directory member",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/directory_members/" + args[0] + "/history")
+			path := fmt.Sprintf("/api/v1/directory_members/%s/history?page=%d&limit=%d", args[0], page, limit)
+			if orderByDirection != "" {
+				path += "&order_by_direction=" + url.QueryEscape(orderByDirection)
+			}
+			if responseFormat != "" {
+				path += "&response_format=" + url.QueryEscape(responseFormat)
+			}
+			data, _, err := apiClient.Get(path)
 			if err != nil {
 				return err
 			}
@@ -333,15 +344,27 @@ func directoryHistoryCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().IntVar(&page, "page", 0, "Page number (0-based)")
+	cmd.Flags().IntVar(&limit, "limit", 25, "Max items to return")
+	cmd.Flags().StringVar(&orderByDirection, "order-by-direction", "", "Sort direction (e.g. asc, desc)")
+	cmd.Flags().StringVar(&responseFormat, "response-format", "", "Response format passthrough to API")
+	return cmd
 }
 
 func directoryRestoreCmd() *cobra.Command {
-	return &cobra.Command{
+	var comments string
+
+	cmd := &cobra.Command{
 		Use:   "restore <member-id>",
 		Short: "Restore a soft-deleted directory member",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Put("/api/v1/directory_members/"+args[0]+"/restore", nil)
+			body := map[string]interface{}{}
+			if comments != "" {
+				body["comments"] = comments
+			}
+			data, _, err := apiClient.Put("/api/v1/directory_members/"+args[0]+"/restore", body)
 			if err != nil {
 				return err
 			}
@@ -353,15 +376,35 @@ func directoryRestoreCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVar(&comments, "comments", "", "Comment stored in version history (defaults to API default \"Restored\")")
+	return cmd
 }
 
 func directoryTestCmd() *cobra.Command {
-	return &cobra.Command{
+	var timestamp, languageCode string
+
+	cmd := &cobra.Command{
 		Use:   "test <member-id>",
-		Short: "Test extension lookup for a directory member",
-		Args:  cobra.ExactArgs(1),
+		Short: "Test extension lookup for a directory member at a given time",
+		Long: `Test extension lookup for a directory member at a given time.
+
+The API requires a timestamp (ISO 8601). Without --timestamp the CLI
+substitutes the current time in UTC.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/directory_members/" + args[0] + "/test")
+			if timestamp == "" {
+				timestamp = time.Now().UTC().Format(time.RFC3339)
+			}
+			path := fmt.Sprintf(
+				"/api/v1/directory_members/%s/test?timestamp=%s",
+				args[0],
+				url.QueryEscape(timestamp),
+			)
+			if languageCode != "" {
+				path += "&language_code=" + url.QueryEscape(languageCode)
+			}
+			data, _, err := apiClient.Get(path)
 			if err != nil {
 				return err
 			}
@@ -369,4 +412,8 @@ func directoryTestCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVar(&timestamp, "timestamp", "", "ISO 8601 timestamp (defaults to now UTC)")
+	cmd.Flags().StringVar(&languageCode, "language-code", "", "Optional BCP 47 language code (e.g. en-US)")
+	return cmd
 }


### PR DESCRIPTION
## Summary
- Adds three missing `directory` subcommands matching spec endpoints: `history`, `restore`, `test`
- Closes 3/15 of the gaps identified by an OpenAPI vs. CLI coverage diff
- Mirrors the existing `directoryGetCmd` shape; no client-helper changes

PR 1 of 5 in the 100% coverage initiative.

## Test plan
- [x] `go test ./...` passes (3 new tests: TestDirectoryHistory, TestDirectoryRestore, TestDirectoryTest)
- [x] `go build` clean
- [x] `./syllable directory --help` shows the three new subcommands
- [x] `./syllable directory history --help` renders
- [ ] Live smoke against a dev/sandbox org (deferred — destructive verb on a real member would dirty the org)

🤖 Generated with [Claude Code](https://claude.com/claude-code)