### PR TITLE
feat: add insights tools-test, move-files, and queue-work commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -390,6 +390,7 @@ syllable insights workflows update --file workflow.json
 syllable insights workflows delete <workflow-id>
 syllable insights workflows activate <workflow-id>
 syllable insights workflows inactivate <workflow-id>
+syllable insights workflows queue-work --file work.json
 
 # Folders
 syllable insights folders list
@@ -398,6 +399,7 @@ syllable insights folders create --file folder.json
 syllable insights folders update --file folder.json
 syllable insights folders delete <folder-id>
 syllable insights folders files <folder-id>
+syllable insights folders move-files <folder-id> --file move.json
 
 # Tool Configs
 syllable insights tool-configs list
@@ -408,6 +410,9 @@ syllable insights tool-configs delete <config-id>
 
 # Tool Definitions
 syllable insights tool-definitions list
+
+# Test a tool against sample input
+syllable insights tools-test --file sample.json
 ```
 
 ### Custom Messages

--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -186,7 +186,7 @@ func TestOutboundCommandHasSubcommands(t *testing.T) {
 
 func TestInsightsCommandHasSubcommands(t *testing.T) {
 	cmd := insightsCmd()
-	expected := []string{"workflows", "folders", "tool-configs", "tool-definitions"}
+	expected := []string{"workflows", "folders", "tool-configs", "tool-definitions", "tools-test"}
 	subs := make(map[string]bool)
 	for _, c := range cmd.Commands() {
 		subs[c.Name()] = true
@@ -1562,6 +1562,116 @@ func TestDashboardsSessions(t *testing.T) {
 	}
 	if method != "POST" {
 		t.Errorf("expected POST method, got %s", method)
+	}
+}
+
+func TestInsightsToolsTest(t *testing.T) {
+	tmp, _ := os.CreateTemp("", "tools-test-*.json")
+	tmp.WriteString(`{"tool_id":1,"sample":"hello"}`)
+	tmp.Close()
+	defer os.Remove(tmp.Name())
+
+	var method, requestPath string
+	var receivedBody map[string]interface{}
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		requestPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedBody)
+		w.Write([]byte(`{}`))
+	})
+	defer server.Close()
+
+	cmd := insightsToolsTestCmd()
+	cmd.SetArgs([]string{"--file", tmp.Name()})
+	captureStdout(func() {
+		cmd.Execute()
+	})
+
+	if method != "POST" {
+		t.Errorf("expected POST, got %s", method)
+	}
+	if requestPath != "/api/v1/insights/tools-test" {
+		t.Errorf("unexpected path: %s", requestPath)
+	}
+	if receivedBody["sample"] != "hello" {
+		t.Errorf("expected sample=hello, got %v", receivedBody["sample"])
+	}
+}
+
+func TestInsightsToolsTestRequiresFile(t *testing.T) {
+	cmd := insightsToolsTestCmd()
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected error when --file missing")
+	}
+}
+
+func TestInsightsFoldersMoveFiles(t *testing.T) {
+	tmp, _ := os.CreateTemp("", "move-*.json")
+	tmp.WriteString(`{"file_ids":[1,2],"target_folder_id":99}`)
+	tmp.Close()
+	defer os.Remove(tmp.Name())
+
+	var method, requestPath string
+	var receivedBody map[string]interface{}
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		requestPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedBody)
+		w.Write([]byte(`{}`))
+	})
+	defer server.Close()
+
+	cmd := insightsFoldersMoveFilesCmd()
+	cmd.SetArgs([]string{"42", "--file", tmp.Name()})
+	captureStdout(func() {
+		cmd.Execute()
+	})
+
+	if method != "POST" {
+		t.Errorf("expected POST, got %s", method)
+	}
+	if requestPath != "/api/v1/insights/folders/42/move-files" {
+		t.Errorf("unexpected path: %s", requestPath)
+	}
+	if receivedBody["target_folder_id"] != float64(99) {
+		t.Errorf("expected target_folder_id=99, got %v", receivedBody["target_folder_id"])
+	}
+}
+
+func TestInsightsWorkflowsQueueWork(t *testing.T) {
+	tmp, _ := os.CreateTemp("", "queue-*.json")
+	tmp.WriteString(`{"workflow_id":7,"session_ids":["s1","s2"]}`)
+	tmp.Close()
+	defer os.Remove(tmp.Name())
+
+	var method, requestPath string
+	var receivedBody map[string]interface{}
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		requestPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedBody)
+		w.Write([]byte(`{}`))
+	})
+	defer server.Close()
+
+	cmd := insightsWorkflowsQueueWorkCmd()
+	cmd.SetArgs([]string{"--file", tmp.Name()})
+	captureStdout(func() {
+		cmd.Execute()
+	})
+
+	if method != "POST" {
+		t.Errorf("expected POST, got %s", method)
+	}
+	if requestPath != "/api/v1/insights/workflows/queue-work" {
+		t.Errorf("unexpected path: %s", requestPath)
+	}
+	if receivedBody["workflow_id"] != float64(7) {
+		t.Errorf("expected workflow_id=7, got %v", receivedBody["workflow_id"])
 	}
 }
 

--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -1567,7 +1567,8 @@ func TestDashboardsSessions(t *testing.T) {
 
 func TestInsightsToolsTest(t *testing.T) {
 	tmp, _ := os.CreateTemp("", "tools-test-*.json")
-	tmp.WriteString(`{"tool_id":1,"sample":"hello"}`)
+	// Body matches the InsightToolTestInput schema in openapi.json.
+	tmp.WriteString(`{"tool_name":"summary-tool","session_id":283467}`)
 	tmp.Close()
 	defer os.Remove(tmp.Name())
 
@@ -1594,8 +1595,8 @@ func TestInsightsToolsTest(t *testing.T) {
 	if requestPath != "/api/v1/insights/tools-test" {
 		t.Errorf("unexpected path: %s", requestPath)
 	}
-	if receivedBody["sample"] != "hello" {
-		t.Errorf("expected sample=hello, got %v", receivedBody["sample"])
+	if receivedBody["tool_name"] != "summary-tool" {
+		t.Errorf("expected tool_name=summary-tool, got %v", receivedBody["tool_name"])
 	}
 }
 
@@ -1609,7 +1610,8 @@ func TestInsightsToolsTestRequiresFile(t *testing.T) {
 
 func TestInsightsFoldersMoveFiles(t *testing.T) {
 	tmp, _ := os.CreateTemp("", "move-*.json")
-	tmp.WriteString(`{"file_ids":[1,2],"target_folder_id":99}`)
+	// Body matches the InsightsFolderFileMove schema in openapi.json.
+	tmp.WriteString(`{"destination_folder_id":99,"file_id_list":[12334,23445]}`)
 	tmp.Close()
 	defer os.Remove(tmp.Name())
 
@@ -1636,14 +1638,15 @@ func TestInsightsFoldersMoveFiles(t *testing.T) {
 	if requestPath != "/api/v1/insights/folders/42/move-files" {
 		t.Errorf("unexpected path: %s", requestPath)
 	}
-	if receivedBody["target_folder_id"] != float64(99) {
-		t.Errorf("expected target_folder_id=99, got %v", receivedBody["target_folder_id"])
+	if receivedBody["destination_folder_id"] != float64(99) {
+		t.Errorf("expected destination_folder_id=99, got %v", receivedBody["destination_folder_id"])
 	}
 }
 
 func TestInsightsWorkflowsQueueWork(t *testing.T) {
 	tmp, _ := os.CreateTemp("", "queue-*.json")
-	tmp.WriteString(`{"workflow_id":7,"session_ids":["s1","s2"]}`)
+	// Body matches the InsightsWorkflowQueueSession schema in openapi.json.
+	tmp.WriteString(`{"workflow_name":"summary-workflow","session_id_list":[12334,23445]}`)
 	tmp.Close()
 	defer os.Remove(tmp.Name())
 
@@ -1670,8 +1673,8 @@ func TestInsightsWorkflowsQueueWork(t *testing.T) {
 	if requestPath != "/api/v1/insights/workflows/queue-work" {
 		t.Errorf("unexpected path: %s", requestPath)
 	}
-	if receivedBody["workflow_id"] != float64(7) {
-		t.Errorf("expected workflow_id=7, got %v", receivedBody["workflow_id"])
+	if receivedBody["workflow_name"] != "summary-workflow" {
+		t.Errorf("expected workflow_name=summary-workflow, got %v", receivedBody["workflow_name"])
 	}
 }
 

--- a/scripts/syllable-cli/cmd/insights.go
+++ b/scripts/syllable-cli/cmd/insights.go
@@ -46,6 +46,7 @@ func insightsCmd() *cobra.Command {
 	cmd.AddCommand(insightsFoldersCmd())
 	cmd.AddCommand(insightsToolConfigsCmd())
 	cmd.AddCommand(insightsToolDefinitionsCmd())
+	cmd.AddCommand(insightsToolsTestCmd())
 
 	return cmd
 }
@@ -141,6 +142,7 @@ func insightsWorkflowsCmd() *cobra.Command {
 	cmd.AddCommand(insightsWorkflowsDeleteCmd())
 	cmd.AddCommand(insightsWorkflowsActivateCmd())
 	cmd.AddCommand(insightsWorkflowsInactivateCmd())
+	cmd.AddCommand(insightsWorkflowsQueueWorkCmd())
 
 	return cmd
 }
@@ -417,6 +419,7 @@ func insightsFoldersCmd() *cobra.Command {
 	cmd.AddCommand(insightsFoldersDeleteCmd())
 	cmd.AddCommand(insightsFoldersFilesCmd())
 	cmd.AddCommand(insightsFoldersUploadFileCmd())
+	cmd.AddCommand(insightsFoldersMoveFilesCmd())
 
 	return cmd
 }
@@ -862,4 +865,114 @@ func insightsToolDefinitionsCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+// ── Tools Test ───────────────────────────────────────────────────────────────
+
+func insightsToolsTestCmd() *cobra.Command {
+	var file string
+
+	cmd := &cobra.Command{
+		Use:   "tools-test",
+		Short: "Test an insight tool against a sample input",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var body interface{}
+
+			if file == "" {
+				return fmt.Errorf("required flag: --file")
+			}
+			fileData, err := readFile(file)
+			if err != nil {
+				return fmt.Errorf("reading file: %w", err)
+			}
+			if err := json.Unmarshal(fileData, &body); err != nil {
+				return fmt.Errorf("parsing JSON file: %w", err)
+			}
+
+			data, _, err := apiClient.Post("/api/v1/insights/tools-test", body)
+			if err != nil {
+				return err
+			}
+
+			output.PrintJSON(data)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&file, "file", "", "Path to JSON body file (use '-' for stdin)")
+	return cmd
+}
+
+// ── Move Files ───────────────────────────────────────────────────────────────
+
+func insightsFoldersMoveFilesCmd() *cobra.Command {
+	var file string
+
+	cmd := &cobra.Command{
+		Use:   "move-files <folder-id>",
+		Short: "Move files between insight folders",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var body interface{}
+
+			if file == "" {
+				return fmt.Errorf("required flag: --file")
+			}
+			fileData, err := readFile(file)
+			if err != nil {
+				return fmt.Errorf("reading file: %w", err)
+			}
+			if err := json.Unmarshal(fileData, &body); err != nil {
+				return fmt.Errorf("parsing JSON file: %w", err)
+			}
+
+			path := fmt.Sprintf("/api/v1/insights/folders/%s/move-files", args[0])
+			data, _, err := apiClient.Post(path, body)
+			if err != nil {
+				return err
+			}
+
+			output.PrintJSON(data)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&file, "file", "", "Path to JSON body file (use '-' for stdin)")
+	return cmd
+}
+
+// ── Workflows Queue Work ─────────────────────────────────────────────────────
+
+func insightsWorkflowsQueueWorkCmd() *cobra.Command {
+	var file string
+
+	cmd := &cobra.Command{
+		Use:   "queue-work",
+		Short: "Queue insight workflow runs for sessions or files",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var body interface{}
+
+			if file == "" {
+				return fmt.Errorf("required flag: --file")
+			}
+			fileData, err := readFile(file)
+			if err != nil {
+				return fmt.Errorf("reading file: %w", err)
+			}
+			if err := json.Unmarshal(fileData, &body); err != nil {
+				return fmt.Errorf("parsing JSON file: %w", err)
+			}
+
+			data, _, err := apiClient.Post("/api/v1/insights/workflows/queue-work", body)
+			if err != nil {
+				return err
+			}
+
+			output.PrintJSON(data)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&file, "file", "", "Path to JSON body file (use '-' for stdin)")
+	return cmd
 }


### PR DESCRIPTION
## Summary
- Adds three missing `insights` subcommands matching spec endpoints:
  - `insights tools-test --file body.json` → `POST /api/v1/insights/tools-test`
  - `insights folders move-files <folder-id> --file body.json` → `POST /api/v1/insights/folders/{id}/move-files`
  - `insights workflows queue-work --file body.json` → `POST /api/v1/insights/workflows/queue-work`
- Closes 3/15 of the gaps identified by an OpenAPI vs. CLI coverage diff
- All three accept stdin via `--file -` (standard `--file` pattern)

PR 2 of 5 in the 100% coverage initiative. Independent of PR #59.

## Test plan
- [x] `go test ./...` passes (4 new tests)
- [x] `go build` clean
- [x] `--help` renders for all three commands
- [ ] Live smoke against a dev/sandbox org (deferred — `queue-work` mutates real state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)