### PR TITLE
fix: gate pronunciations upload-csv and delete-csv behind --confirm

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -500,10 +500,11 @@ Custom TTS pronunciation dictionary. Downloadable as CSV.
 ```bash
 syllable pronunciations list
 syllable pronunciations get-csv
-syllable pronunciations upload-csv --file pronunciations.csv
-syllable pronunciations delete-csv
+syllable pronunciations upload-csv --file pronunciations.csv --confirm
+syllable pronunciations delete-csv --confirm
 syllable pronunciations metadata
 ```
+**`upload-csv` and `delete-csv` modify the org-wide pronunciation dictionary, which every live agent picks up immediately. Both require `--confirm`.**
 
 ### Session Labels
 Manual annotations on sessions: rating (Bad/OK/Good/N/A), issue category, freetext notes. **CONSTRAINT: Immutable — once a label is added to a session, it cannot be updated or deleted.** There is no update or delete subcommand.

--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -1752,7 +1752,7 @@ func TestPronunciationsUploadCSV(t *testing.T) {
 	defer server.Close()
 
 	cmd := pronunciationsUploadCSVCmd()
-	cmd.SetArgs([]string{"--file", tmp.Name()})
+	cmd.SetArgs([]string{"--file", tmp.Name(), "--confirm"})
 	captureStdout(func() {
 		cmd.Execute()
 	})
@@ -1768,6 +1768,24 @@ func TestPronunciationsUploadCSV(t *testing.T) {
 	}
 }
 
+func TestPronunciationsUploadCSVRequiresConfirm(t *testing.T) {
+	tmp, _ := os.CreateTemp("", "pron-*.csv")
+	tmp.WriteString("word,pronunciation\n")
+	tmp.Close()
+	defer os.Remove(tmp.Name())
+
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("server should not be hit without --confirm")
+	})
+	defer server.Close()
+
+	cmd := pronunciationsUploadCSVCmd()
+	cmd.SetArgs([]string{"--file", tmp.Name()})
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected error without --confirm")
+	}
+}
+
 func TestPronunciationsDeleteCSV(t *testing.T) {
 	var method, path string
 	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
@@ -1778,7 +1796,7 @@ func TestPronunciationsDeleteCSV(t *testing.T) {
 	defer server.Close()
 
 	cmd := pronunciationsDeleteCSVCmd()
-	cmd.SetArgs([]string{})
+	cmd.SetArgs([]string{"--confirm"})
 	captureStdout(func() {
 		cmd.Execute()
 	})
@@ -1788,6 +1806,19 @@ func TestPronunciationsDeleteCSV(t *testing.T) {
 	}
 	if path != "/api/v1/pronunciations/csv" {
 		t.Errorf("unexpected path: %s", path)
+	}
+}
+
+func TestPronunciationsDeleteCSVRequiresConfirm(t *testing.T) {
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("server should not be hit without --confirm")
+	})
+	defer server.Close()
+
+	cmd := pronunciationsDeleteCSVCmd()
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected error without --confirm")
 	}
 }
 

--- a/scripts/syllable-cli/cmd/pronunciations.go
+++ b/scripts/syllable-cli/cmd/pronunciations.go
@@ -12,7 +12,11 @@ func pronunciationsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pronunciations",
 		Short: "Manage pronunciations",
-		Long:  "List, download CSV, upload CSV, delete CSV, and get metadata for pronunciations.",
+		Long: `List, download CSV, upload CSV, delete CSV, and get metadata for pronunciations.
+
+The pronunciation dictionary is org-wide and applies to every agent at runtime.
+upload-csv and delete-csv affect every live agent immediately, so they require
+an explicit --confirm flag.`,
 		Example: `  # List all pronunciations
   syllable pronunciations list
 
@@ -22,11 +26,11 @@ func pronunciationsCmd() *cobra.Command {
   # Save the CSV to a file
   syllable pronunciations get-csv > pronunciations.csv
 
-  # Upload pronunciations from a CSV file
-  syllable pronunciations upload-csv --file pronunciations.csv
+  # Upload pronunciations from a CSV file (replaces the org dictionary)
+  syllable pronunciations upload-csv --file pronunciations.csv --confirm
 
   # Wipe the pronunciations dictionary
-  syllable pronunciations delete-csv
+  syllable pronunciations delete-csv --confirm
 
   # Get pronunciations metadata
   syllable pronunciations metadata`,
@@ -43,13 +47,22 @@ func pronunciationsCmd() *cobra.Command {
 
 func pronunciationsUploadCSVCmd() *cobra.Command {
 	var file string
+	var confirm bool
 
 	cmd := &cobra.Command{
 		Use:   "upload-csv",
-		Short: "Upload a pronunciations CSV",
+		Short: "Upload a pronunciations CSV (requires --confirm)",
+		Long: `Upload a pronunciations CSV.
+
+This **replaces** the org-wide pronunciation dictionary. Every live agent
+will pick up the new pronunciations on its next synthesis call. The
+--confirm flag is required to prevent accidental dictionary clobbers.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if file == "" {
 				return fmt.Errorf("required flag: --file")
+			}
+			if !confirm {
+				return fmt.Errorf("refusing to replace the org-wide pronunciation dictionary without --confirm")
 			}
 			data, _, err := apiClient.PostMultipart("/api/v1/pronunciations/csv", "file", file)
 			if err != nil {
@@ -61,14 +74,24 @@ func pronunciationsUploadCSVCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&file, "file", "", "Path to local CSV file (use '-' for stdin)")
+	cmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm replacing the org-wide pronunciation dictionary")
 	return cmd
 }
 
 func pronunciationsDeleteCSVCmd() *cobra.Command {
-	return &cobra.Command{
+	var confirm bool
+
+	cmd := &cobra.Command{
 		Use:   "delete-csv",
-		Short: "Delete the pronunciations dictionary",
+		Short: "Delete the pronunciations dictionary (requires --confirm)",
+		Long: `Delete the org-wide pronunciation dictionary.
+
+Every live agent loses its custom pronunciations immediately. The --confirm
+flag is required to prevent a typo from wiping the dictionary.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if !confirm {
+				return fmt.Errorf("refusing to delete the org-wide pronunciation dictionary without --confirm")
+			}
 			data, _, err := apiClient.Delete("/api/v1/pronunciations/csv")
 			if err != nil {
 				return err
@@ -76,13 +99,14 @@ func pronunciationsDeleteCSVCmd() *cobra.Command {
 			if len(data) > 0 {
 				output.PrintJSON(data)
 			} else {
-				// Match other delete commands (directory, agents, voice-groups,
-				// etc.) which print success messages to stdout.
 				fmt.Println("Pronunciations dictionary deleted.")
 			}
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm deleting the org-wide pronunciation dictionary")
+	return cmd
 }
 
 func pronunciationsListCmd() *cobra.Command {


### PR DESCRIPTION
## Summary
Both `pronunciations upload-csv` and `pronunciations delete-csv` modify the **org-wide** pronunciation dictionary, which every live agent reads at synthesis time. A typo or autocomplete on either command silently degrades speech output across the org. Both now require `--confirm`.

## Why
Self-review of the recent coverage work flagged these two as high-blast-radius operations that shipped without any safety gate. The precedent is `users delete-account` (PR #63) — explicit `--confirm` required, no shorthand, server is never hit if the gate fails.

`pronunciations delete-csv` is irreversible at the API level — there is no `restore` endpoint. `upload-csv` is technically recoverable (re-upload an old CSV) but only if you have the previous version saved.

## Changes
- `pronunciationsUploadCSVCmd` and `pronunciationsDeleteCSVCmd` now check `--confirm` before any network call
- Both commands return a non-zero error without `--confirm`
- New tests `TestPronunciationsUploadCSVRequiresConfirm` and `TestPronunciationsDeleteCSVRequiresConfirm` assert the gate
- Existing functional tests updated to pass `--confirm`
- `AGENTS.md` documents the gate

## Test plan
- [x] `go test ./...` passes (2 new gate tests, 2 functional tests still pass)
- [x] `go build` clean
- [x] `./syllable pronunciations delete-csv --help` shows `--confirm` flag
- [x] Without `--confirm` both commands error out before hitting the server (verified by tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)