### PR TITLE
feat: add --override-timestamp to agents send-test-message

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,7 +247,7 @@ syllable completion powershell > syllable.ps1
 ## Commands
 
 ### Agents
-Agents are AI systems that communicate with users via channels. Configured with a prompt, timezone, optional opening message, session variables (`{vars.session_variable}` syntax), tool headers, and optional voice group. **Constraint: 1:1 with channel target.** A test channel is auto-generated for each agent.
+Agents are AI systems that communicate with users via channels. Configured with a prompt, timezone, optional opening message, session variables (`{vars.session_variable}` syntax), tool headers, and optional voice group. **Constraint: 1:1 with channel target.** A test channel is auto-generated for each agent. `send-test-message` exchanges a single turn with an agent via the conversation-test API (`POST /api/v1/agents/test/messages`): pass `--session-start` on the first turn and reuse `--test-id` for follow-ups; `--override-timestamp <iso8601>` pins the agent's wall-clock time for deterministic date-sensitive tests (omit to use the current time).
 ```bash
 syllable agents list [--page N] [--limit N] [--search TEXT]
 syllable agents get <agent-id>
@@ -256,6 +256,7 @@ syllable agents create --name NAME --type TYPE --prompt-id ID --timezone TZ
 syllable agents update <agent-id> --file agent.json
 syllable agents delete <agent-id>
 syllable agents voices
+syllable agents send-test-message <agent-id> --test-id ID [--session-start] [--text TEXT] [--override-timestamp ISO8601]
 ```
 **Table columns:** ID, NAME, TYPE, LABEL, DESCRIPTION, UPDATED
 

--- a/scripts/syllable-cli/cmd/agents.go
+++ b/scripts/syllable-cli/cmd/agents.go
@@ -310,7 +310,7 @@ func agentsDeleteCmd() *cobra.Command {
 }
 
 func agentsSendTestMessageCmd() *cobra.Command {
-	var testID, text, serviceName, source string
+	var testID, text, serviceName, source, overrideTimestamp string
 	var sessionStart bool
 	var timeout int
 
@@ -330,7 +330,10 @@ the same --test-id).`,
   syllable agents send-test-message 42 --test-id my-test-1 --text "Yes, that's correct"
 
   # Start a session with no caller text (agent speaks first)
-  syllable agents send-test-message 42 --test-id my-test-1 --session-start`,
+  syllable agents send-test-message 42 --test-id my-test-1 --session-start
+
+  # Pin the agent's wall-clock time for deterministic date-sensitive tests
+  syllable agents send-test-message 42 --test-id my-test-1 --session-start --override-timestamp "2026-05-30T10:00:00-07:00" --text "I need to schedule an appointment"`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			agentID := args[0]
@@ -346,6 +349,9 @@ the same --test-id).`,
 				body["text"] = text
 			} else if sessionStart {
 				body["text"] = ""
+			}
+			if cmd.Flags().Changed("override-timestamp") {
+				body["override_timestamp"] = overrideTimestamp
 			}
 
 			data, _, err := apiClient.PostWithTimeout(
@@ -386,6 +392,7 @@ the same --test-id).`,
 
 	cmd.Flags().StringVar(&testID, "test-id", "", "Test session identifier (required)")
 	cmd.Flags().StringVar(&text, "text", "", "Message text to send to the agent")
+	cmd.Flags().StringVar(&overrideTimestamp, "override-timestamp", "", "ISO 8601 timestamp to pin the agent's wall-clock time for this turn (forwarded as override_timestamp). Omit to use current time.")
 	cmd.Flags().BoolVar(&sessionStart, "session-start", false, "Start a new test session")
 	cmd.Flags().StringVar(&serviceName, "service-name", "test", "Service name for the test")
 	cmd.Flags().StringVar(&source, "source", "tester@syllable.ai", "Source identifier for the test caller")

--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -595,6 +595,60 @@ func TestAgentsSendTestMessageEmptyTextSendsField(t *testing.T) {
 	}
 }
 
+func TestAgentsSendTestMessageOverrideTimestamp(t *testing.T) {
+	var receivedBody map[string]interface{}
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedBody)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"test_id":  "test-ts",
+			"agent_id": "42",
+		})
+	})
+	defer server.Close()
+
+	cmd := agentsSendTestMessageCmd()
+	cmd.SetArgs([]string{"42", "--test-id", "test-ts", "--session-start", "--override-timestamp", "2026-05-30T10:00:00-07:00"})
+	captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	val, exists := receivedBody["override_timestamp"]
+	if !exists {
+		t.Fatal("override_timestamp should be present when --override-timestamp is provided")
+	}
+	if val != "2026-05-30T10:00:00-07:00" {
+		t.Errorf("expected override_timestamp=2026-05-30T10:00:00-07:00, got %v", val)
+	}
+}
+
+func TestAgentsSendTestMessageNoOverrideTimestampOmitsField(t *testing.T) {
+	var receivedBody map[string]interface{}
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedBody)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"test_id":  "test-no-ts",
+			"agent_id": "42",
+		})
+	})
+	defer server.Close()
+
+	cmd := agentsSendTestMessageCmd()
+	cmd.SetArgs([]string{"42", "--test-id", "test-no-ts", "--session-start", "--text", "hi"})
+	captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if _, exists := receivedBody["override_timestamp"]; exists {
+		t.Errorf("override_timestamp should be omitted when --override-timestamp is not provided, got %v", receivedBody["override_timestamp"])
+	}
+}
+
 // --- Tools functional tests ---
 
 func TestToolsList(t *testing.T) {


### PR DESCRIPTION
## What & why

Adds an `--override-timestamp <iso8601>` flag to `syllable agents send-test-message`, bringing the CLI to parity with the conversation-test API (`POST /api/v1/agents/test/messages`), whose `TestMessage` schema already supports `override_timestamp`.

Date-sensitive agent tests (relative-date fixtures, "two weeks from today") drift daily because the agent's `@get_current_datetime` returns the real wall clock. This flag pins the agent's time for a turn so those tests are deterministic — without dropping to raw HTTP and re-implementing config/auth resolution.

Resolves **ZOO-7809**.

## Behavior

- **Set** → value forwarded verbatim into the request body's `override_timestamp`.
- **Unset** → field omitted entirely; existing invocations produce a byte-identical body.
- **Thin passthrough** — no client-side validation; the server validates format and returns a structured 422.

## Changes

- `cmd/agents.go` — new flag on `agentsSendTestMessageCmd()`, conditional body inclusion via `cmd.Flags().Changed(...)` (mirrors the sibling `--text` pattern), plus help text and an example.
- `cmd/cmd_test.go` — two tests: field present when set, omitted when unset.
- `AGENTS.md` — documents `send-test-message` in the Agents section (previously undocumented).

No spec change — `override_timestamp` already exists in the embedded `TestMessage` schema.

## Verification

- `go build` ✅ · `go test ./...` ✅ · `go vet ./cmd/` ✅
- `--help` lists `--override-timestamp` with an ISO 8601 example.
- `--dry-run` includes `override_timestamp` iff the flag is passed; the omitted-field body is identical to today's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
