### PR TITLE
fix: correct send-test-message --override-timestamp docs to tz-naive format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,7 +247,7 @@ syllable completion powershell > syllable.ps1
 ## Commands
 
 ### Agents
-Agents are AI systems that communicate with users via channels. Configured with a prompt, timezone, optional opening message, session variables (`{vars.session_variable}` syntax), tool headers, and optional voice group. **Constraint: 1:1 with channel target.** A test channel is auto-generated for each agent. `send-test-message` exchanges a single turn with an agent via the conversation-test API (`POST /api/v1/agents/test/messages`): pass `--session-start` on the first turn and reuse `--test-id` for follow-ups; `--override-timestamp <iso8601>` pins the agent's wall-clock time for deterministic date-sensitive tests (omit to use the current time).
+Agents are AI systems that communicate with users via channels. Configured with a prompt, timezone, optional opening message, session variables (`{vars.session_variable}` syntax), tool headers, and optional voice group. **Constraint: 1:1 with channel target.** A test channel is auto-generated for each agent. `send-test-message` exchanges a single turn with an agent via the conversation-test API (`POST /api/v1/agents/test/messages`): pass `--session-start` on the first turn and reuse `--test-id` for follow-ups; `--override-timestamp` pins the agent's wall clock for deterministic date-sensitive tests and must be a **timezone-naive** ISO 8601 value like `2030-12-25T09:30:00` (interpreted in the agent's timezone) — offset, `Z`, and space-separated forms are silently ignored by the server (omit to use the current time).
 ```bash
 syllable agents list [--page N] [--limit N] [--search TEXT]
 syllable agents get <agent-id>

--- a/scripts/syllable-cli/cmd/agents.go
+++ b/scripts/syllable-cli/cmd/agents.go
@@ -332,8 +332,8 @@ the same --test-id).`,
   # Start a session with no caller text (agent speaks first)
   syllable agents send-test-message 42 --test-id my-test-1 --session-start
 
-  # Pin the agent's wall-clock time for deterministic date-sensitive tests
-  syllable agents send-test-message 42 --test-id my-test-1 --session-start --override-timestamp "2026-05-30T10:00:00-07:00" --text "I need to schedule an appointment"`,
+  # Pin the agent's wall clock for deterministic date-sensitive tests (timezone-naive ISO 8601, interpreted in the agent's timezone)
+  syllable agents send-test-message 42 --test-id my-test-1 --session-start --override-timestamp "2030-12-25T09:30:00" --text "I need to schedule an appointment"`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			agentID := args[0]
@@ -392,7 +392,7 @@ the same --test-id).`,
 
 	cmd.Flags().StringVar(&testID, "test-id", "", "Test session identifier (required)")
 	cmd.Flags().StringVar(&text, "text", "", "Message text to send to the agent")
-	cmd.Flags().StringVar(&overrideTimestamp, "override-timestamp", "", "ISO 8601 timestamp to pin the agent's wall-clock time for this turn (forwarded as override_timestamp). Omit to use current time.")
+	cmd.Flags().StringVar(&overrideTimestamp, "override-timestamp", "", "Timezone-naive ISO 8601 timestamp (e.g. 2030-12-25T09:30:00) to pin the agent's wall clock for this turn, interpreted in the agent's timezone. Offset (-07:00), 'Z', and space-separated forms are silently ignored by the server. Omit to use current time.")
 	cmd.Flags().BoolVar(&sessionStart, "session-start", false, "Start a new test session")
 	cmd.Flags().StringVar(&serviceName, "service-name", "test", "Service name for the test")
 	cmd.Flags().StringVar(&source, "source", "tester@syllable.ai", "Source identifier for the test caller")

--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -608,7 +608,7 @@ func TestAgentsSendTestMessageOverrideTimestamp(t *testing.T) {
 	defer server.Close()
 
 	cmd := agentsSendTestMessageCmd()
-	cmd.SetArgs([]string{"42", "--test-id", "test-ts", "--session-start", "--override-timestamp", "2026-05-30T10:00:00-07:00"})
+	cmd.SetArgs([]string{"42", "--test-id", "test-ts", "--session-start", "--override-timestamp", "2030-12-25T09:30:00"})
 	captureStdout(func() {
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -619,8 +619,8 @@ func TestAgentsSendTestMessageOverrideTimestamp(t *testing.T) {
 	if !exists {
 		t.Fatal("override_timestamp should be present when --override-timestamp is provided")
 	}
-	if val != "2026-05-30T10:00:00-07:00" {
-		t.Errorf("expected override_timestamp=2026-05-30T10:00:00-07:00, got %v", val)
+	if val != "2030-12-25T09:30:00" {
+		t.Errorf("expected override_timestamp=2030-12-25T09:30:00, got %v", val)
 	}
 }
 


### PR DESCRIPTION
## What & why

The `--override-timestamp` flag added in #74 forwards correctly at the CLI layer, but the **example** shipped in `--help` and `AGENTS.md` used `2026-05-30T10:00:00-07:00` — an **offset** form the conversation-test server **silently ignores** (returns HTTP 200, falls back to the real clock). Copy-pasting it was a no-op that defeated the flag's whole purpose (deterministic date-sensitive tests, ZOO-7809).

Per the reporter's verification (issue #76), the server honors `override_timestamp` **only** when it is a **timezone-naive** ISO 8601 string (`2030-12-25T09:30:00`, interpreted in the agent's timezone); offset, `Z`, space-separated, and invalid forms are all silently dropped.

Closes #76.

## Changes (docs/test only — no behavior change)

- `cmd/agents.go` — `--help` example → tz-naive `2030-12-25T09:30:00`; flag help now states the server only honors tz-naive and names the ignored forms.
- `AGENTS.md` — same caveat in the Agents descriptor.
- `cmd/cmd_test.go` — the override-timestamp test asserted on the offset form (it was demonstrating the broken format); updated to the tz-naive value.

## Not in scope (follow-up)

- Client-side guard to **warn** when a server-ignored form is passed (fail loud instead of silent) → tracked in #77.
- Correction of record: #74's "server validates format and returns a structured 422" was wrong — `override_timestamp` is `anyOf[string,null]` with no `date-time` format, so there's no schema-level validation; invalid input returns 200.

## Verification

- `go build` ✅ · CI-equivalent `go test $(go list ./... | grep -v /integration)` ✅
- No stale `...-07:00` references remain in `*.go`/`*.md`.
- `--help` now shows the tz-naive example and the "silently ignored" caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
