### PR TITLE
chore: bump GitHub Actions to Node.js 24-compatible majors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,18 +14,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: scripts/syllable-cli/go.mod
           cache-dependency-path: scripts/syllable-cli/go.sum
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: scripts/syllable-cli/go.mod
           cache-dependency-path: scripts/syllable-cli/go.sum


### PR DESCRIPTION
## What & why

Node.js 20 GitHub Actions are [deprecated](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/): GitHub **force-upgrades them to Node 24 on 2026-06-02** and removes Node 20 from runners on 2026-09-16. The release run flagged three actions running on Node 20.

Bumps each to its latest major that runs on Node 24 — verified against the live action repos (`runs.using: node24`):

| Action | From | To |
|--------|------|----|
| `actions/checkout` | v4 | **v6** (v6.0.2) |
| `actions/setup-go` | v5 | **v6** (v6.4.0) |
| `goreleaser/goreleaser-action` | v6 | **v7** (v7.2.2) |

(Checkout is at v6, not v5 — the major moved twice since v4.)

## Safety

Every input we use is unchanged across these majors — `fetch-depth`, `go-version-file`, `cache-dependency-path`, and goreleaser's `distribution`/`version`/`args`. Runtime bump only; no config changes.

## Verification

- YAML parses; no Node-20 pins remain in either workflow.
- `test.yml` runs on this PR — the "Node.js 20 actions are deprecated" annotation should no longer appear.
- `release.yml` only runs on `v*` tags, so it's exercised at the next release; the action bumps there are identical and verified `node24`.

Closes #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
