### PR TITLE
feat: SYLLABLE_API_KEY env auth (unblocks CI integration tests)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ cd scripts/syllable-cli && go test ./...
 
 Run `syllable setup` to open the browser-based config UI. This manages orgs, API keys, and environments in `~/.syllable/config.yaml`. Never edit that file directly or ask the user to paste keys into the terminal.
 
+For non-interactive use (CI, scripts, automation), set the `SYLLABLE_API_KEY` environment variable instead — the CLI reads it directly and it takes priority over the config file, so no `syllable setup` or `--org` is needed.
+
 ## Key Flags
 
 | Flag | Purpose |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ SYLLABLE_API_KEY=... go test ./integration/...
 SYLLABLE_ORG=sandbox go test ./integration/...
 ```
 
-The default org slug is `sandbox`. **Do not point integration tests at customer orgs.** The org slugs in [AGENTS.md](AGENTS.md) examples (`acme`, `globex`, etc.) are placeholders, not test targets.
+`SYLLABLE_API_KEY` is read directly by the CLI (no config file needed — this is how CI authenticates); `SYLLABLE_ORG` instead resolves the key from `~/.syllable/config.yaml`. **Do not point integration tests at customer orgs** — use a dedicated throwaway org such as `cli-test`. The org slugs in [AGENTS.md](AGENTS.md) examples (`acme`, `globex`, etc.) are placeholders, not test targets.
 
 ## Branch and release workflow
 

--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -624,6 +624,16 @@ func TestAgentsSendTestMessageOverrideTimestamp(t *testing.T) {
 	}
 }
 
+// TestResolveAPIKeyFromEnv verifies the non-interactive auth path: a key in
+// SYLLABLE_API_KEY is used directly, taking priority over config resolution
+// (so the CLI authenticates in CI/automation with no ~/.syllable/config.yaml).
+func TestResolveAPIKeyFromEnv(t *testing.T) {
+	t.Setenv("SYLLABLE_API_KEY", "env-key-abc123")
+	if got := resolveAPIKey(); got != "env-key-abc123" {
+		t.Errorf("resolveAPIKey() = %q, want %q (SYLLABLE_API_KEY should take priority)", got, "env-key-abc123")
+	}
+}
+
 func TestAgentsSendTestMessageNoOverrideTimestampOmitsField(t *testing.T) {
 	var receivedBody map[string]interface{}
 	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/scripts/syllable-cli/cmd/root.go
+++ b/scripts/syllable-cli/cmd/root.go
@@ -196,7 +196,7 @@ func init() {
 
 	// Global flags
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default: ~/.syllable/config.yaml)")
-	rootCmd.PersistentFlags().StringVar(&orgName, "org", "", "Organization name (e.g. sandbox, memorialcare)")
+	rootCmd.PersistentFlags().StringVar(&orgName, "org", "", "Organization name (e.g. sandbox)")
 	rootCmd.PersistentFlags().StringVar(&envName, "env", "", "Named environment — sets base URL from config (default: prod)")
 	rootCmd.PersistentFlags().StringVarP(&outputFmt, "output", "o", "table", "Output format: table or json")
 	rootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "Print the request that would be sent without executing it")
@@ -266,7 +266,7 @@ func initClient() {
 	key := resolveAPIKey()
 
 	if key == "" {
-		fmt.Fprintln(os.Stderr, "Error: not configured. Run `syllable setup` to configure orgs and API keys, then use --org <name> to select one.")
+		fmt.Fprintln(os.Stderr, "Error: not configured. Run `syllable setup` and select an org with --org <name>, or set SYLLABLE_API_KEY for non-interactive use.")
 		os.Exit(1)
 	}
 
@@ -279,6 +279,12 @@ func initClient() {
 // Priority: orgs.<org>.envs.<env>.api_key > orgs.<org>.api_key
 // Org is taken from --org flag or default_org in config.
 func resolveAPIKey() string {
+	// Non-interactive auth: an explicit key in the environment takes priority,
+	// so the CLI works in CI and automation without a ~/.syllable/config.yaml.
+	if k := os.Getenv("SYLLABLE_API_KEY"); k != "" {
+		return k
+	}
+
 	org := strings.ToLower(viper.GetString("org"))
 	if org == "" {
 		org = strings.ToLower(viper.GetString("default_org"))

--- a/scripts/syllable-cli/integration/helpers_test.go
+++ b/scripts/syllable-cli/integration/helpers_test.go
@@ -16,24 +16,22 @@ import (
 
 var (
 	cliBinary string
-	baseURL   string
-	apiKey    string // direct key (no org lookup)
-	org       string // org name (key looked up from config file)
+	org       string // org name; key is resolved by the CLI from ~/.syllable/config.yaml
+	env       string // optional named environment (selects base URL + per-env key)
 )
 
 // initConfig populates the test config from environment variables.
 //
-// Auth: prefers --org (reads key from ~/.syllable/config.yaml) over --api-key,
-// so set SYLLABLE_ORG to pick the right org. SYLLABLE_API_KEY is used only
-// when SYLLABLE_ORG is not set.
-//
-// Base URL: defaults to https://api.syllable.cloud. Override with SYLLABLE_TEST_BASE_URL
-// (NOT SYLLABLE_BASE_URL, to avoid accidentally picking up shell env pointing to staging).
+// Auth (either works):
+//   - SYLLABLE_API_KEY — the CLI reads this key directly (non-interactive / CI).
+//   - SYLLABLE_ORG     — the CLI resolves that org's key from ~/.syllable/config.yaml
+//                        (local dev; configure it with `syllable setup`).
+// The CLI has no --api-key/--base-url flag. Set SYLLABLE_ENV for a non-default
+// environment; base URL defaults to prod (https://api.syllable.cloud).
 func initConfig() {
 	cliBinary = envOr("SYLLABLE_CLI_BINARY", "../syllable")
-	baseURL = envOr("SYLLABLE_TEST_BASE_URL", "https://api.syllable.cloud")
-	apiKey = os.Getenv("SYLLABLE_API_KEY")
 	org = os.Getenv("SYLLABLE_ORG")
+	env = os.Getenv("SYLLABLE_ENV")
 }
 
 func envOr(key, def string) string {
@@ -70,15 +68,16 @@ func runCleanup() {
 // CLI runner
 // ---------------------------------------------------------------------------
 
-// runCLI executes the CLI binary with the given args, always injecting
-// --base-url and -o json. Auth is either --api-key (if SYLLABLE_API_KEY is
-// set) or --org (if SYLLABLE_ORG is set, reads key from ~/.syllable/config.yaml).
+// runCLI executes the CLI binary with the given args, injecting -o json (plus
+// --org when SYLLABLE_ORG is set and --env when SYLLABLE_ENV is set). The CLI
+// gets its key from SYLLABLE_API_KEY (inherited env) or that org's config entry.
 func runCLI(args ...string) ([]byte, error) {
-	base := []string{"--base-url", baseURL, "-o", "json"}
-	if apiKey != "" {
-		base = append(base, "--api-key", apiKey)
-	} else {
+	base := []string{"-o", "json"}
+	if org != "" {
 		base = append(base, "--org", org)
+	}
+	if env != "" {
+		base = append(base, "--env", env)
 	}
 	full := append(base, args...)
 	cmd := exec.Command(cliBinary, full...)

--- a/scripts/syllable-cli/integration/integration_test.go
+++ b/scripts/syllable-cli/integration/integration_test.go
@@ -1,14 +1,14 @@
 // Package integration_test runs black-box CRUD tests against a live Syllable
 // instance by invoking the CLI binary as a subprocess.
 //
-// Required env vars:
+// Auth — set one of:
 //
-//	SYLLABLE_API_KEY   — API key for the test org
+//	SYLLABLE_API_KEY   — API key used directly (non-interactive / CI)
+//	SYLLABLE_ORG       — org whose key is read from ~/.syllable/config.yaml (local dev)
 //
 // Optional env vars:
 //
-//	SYLLABLE_ORG              — org slug (default: sandbox)
-//	SYLLABLE_BASE_URL         — base URL (default: https://api.syllable.cloud)
+//	SYLLABLE_ENV              — named environment (default: prod)
 //	SYLLABLE_CLI_BINARY       — path to CLI binary (default: ../syllable)
 //	SYLLABLE_TOOL_SERVICE_ID  — integer service ID; enables TestToolsCRUD
 //	SYLLABLE_TEST_CALLER_ID   — phone number; enables TestOutboundCampaignsCRUD
@@ -27,11 +27,9 @@ import (
 func TestMain(m *testing.M) {
 	initConfig()
 
-	// Require at least one auth method.
-	// Prefer SYLLABLE_ORG (looks up key from ~/.syllable/config.yaml).
-	// Fall back to SYLLABLE_API_KEY for keyless-config environments.
-	if apiKey == "" && org == "" {
-		fmt.Fprintln(os.Stderr, "Set SYLLABLE_ORG or SYLLABLE_API_KEY to run integration tests")
+	// Require an auth source: SYLLABLE_API_KEY (direct) or SYLLABLE_ORG (config).
+	if org == "" && os.Getenv("SYLLABLE_API_KEY") == "" {
+		fmt.Fprintln(os.Stderr, "Set SYLLABLE_API_KEY or SYLLABLE_ORG to run integration tests")
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
## Why

`spec-live-check.yml` (from #83) failed on its first real run — every integration test errored with `unknown flag: --base-url`. The root cause was deeper than a flag: the CLI authenticated **only** from `~/.syllable/config.yaml` (no `--api-key`/`--base-url` flag, no env var), so it couldn't authenticate in CI/automation at all, and the integration suite still used long-removed flags.

The right fix (not a workaround): make the CLI accept a credential from the environment, like any tool built for automation.

## What

- **`SYLLABLE_API_KEY` env auth** — `resolveAPIKey` returns it when set, taking priority over config. The CLI now runs headless (CI, routines, scripts) with no `syllable setup`.
- **Integration harness fixed** — drops the dead `--base-url`/`--api-key` flags; injects `--org` only when `SYLLABLE_ORG` is set; lets the CLI read `SYLLABLE_API_KEY` from the inherited env. Runs in CI (key) and locally (config) alike.
- **Unit test** for the env path; **`memorialcare`** scrubbed from the `--org` flag help (customer-name leak).
- **Docs** for non-interactive auth.

`spec-live-check.yml` itself needs no change — it already sets `SYLLABLE_API_KEY` from the secret; it just never worked until the CLI read it.

## Validation

- `go test` (unit, incl. new `TestResolveAPIKeyFromEnv`) ✓
- Dry-run probe: empty config + `SYLLABLE_API_KEY` resolves against prod ✓
- Full integration suite **passed live against `cli-test`** (16s, 0 orphans) ✓
- This PR carries the `spec-sync` label so `spec-live-check.yml` runs the suite live via the **env path** — the CI proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
