### PR TITLE
test: live integration coverage for spec-sync commands (Stage 1)

### DIFF
--- a/.claude/skills/syllable-sync/SKILL.md
+++ b/.claude/skills/syllable-sync/SKILL.md
@@ -197,6 +197,26 @@ For removed fields:
 Before deleting, check `cmd_test.go` for any tests referencing the command and
 remove those too. Then delete the cmd file and remove the `rootCmd.AddCommand()` line.
 
+### Integration tests for new commands
+
+Unit tests (stubbed HTTP in `cmd_test.go`) prove the request shape; they cannot
+catch spec-vs-reality drift. For **every new command**, also add a black-box test
+to `scripts/syllable-cli/integration/integration_test.go` so `spec-live-check.yml`
+exercises it against the live CI org:
+
+- **Mutable resource (create/update/delete):** a full create → list → update →
+  delete cycle, with `registerCleanup` so the resource is removed even on failure.
+  Use a safe, identifiable test value (a TEST-NET-3 `203.0.113.0/24` CIDR, or the
+  `[TEST-INTEG]` prefix via `testName(...)`). See `TestOrganizationsSipIPRangesCRUD`.
+- **Read-only (list/get):** call it with `mustRunCLI` — a clean exit proves the
+  path, auth, and parsing work against the live API. See `TestAgentsLabels`.
+- **Needs a precondition** (an existing tool, a Twilio channel, a phone number):
+  gate it behind an env var and `t.Skip` when unset, like `TestToolsCRUD`
+  (`SYLLABLE_TOOL_SERVICE_ID`) and `TestToolsHistory` (`SYLLABLE_TEST_TOOL_ID`).
+
+A new command with no live test means the QA gate isn't actually covering it —
+say so explicitly in the PR if you genuinely can't add one.
+
 ---
 
 ## Phase 6 — Update documentation

--- a/scripts/syllable-cli/integration/integration_test.go
+++ b/scripts/syllable-cli/integration/integration_test.go
@@ -458,3 +458,71 @@ func TestOutboundCampaignsCRUD(t *testing.T) {
 	// Delete
 	mustRunCLI(t, "outbound", "campaigns", "delete", id)
 }
+
+// ---------------------------------------------------------------------------
+// Agent Labels (read-only) — spec-sync v0.0.3
+// ---------------------------------------------------------------------------
+
+func TestAgentsLabels(t *testing.T) {
+	// Read-only listing; the org may have zero labels. mustRunCLI fails the test
+	// on a non-zero exit, so a clean call proves the command, path, and auth all
+	// work against the live API.
+	mustRunCLI(t, "agents", "labels")
+}
+
+// ---------------------------------------------------------------------------
+// Organization SIP IP Ranges — spec-sync v0.0.3
+// ---------------------------------------------------------------------------
+
+func TestOrganizationsSipIPRangesCRUD(t *testing.T) {
+	// TEST-NET-3 (RFC 5737) — reserved for documentation, safe to create/delete.
+	cidr := "203.0.113.0/24"
+
+	// Create
+	out := mustRunCLI(t, "organizations", "sip-ip-ranges", "create", "--type", "signaling", "--ip-range", cidr)
+	id := mustExtractField(t, out, "id")
+	t.Logf("created sip-ip-range id=%s", id)
+	registerCleanup(func() {
+		runCLI("organizations", "sip-ip-ranges", "delete", id)
+	})
+
+	// List — should include the range we created
+	out = mustRunCLI(t, "organizations", "sip-ip-ranges", "list")
+	assertContains(t, string(out), cidr)
+
+	// Update the CIDR, then confirm via list
+	updated := "203.0.113.0/25"
+	mustRunCLI(t, "organizations", "sip-ip-ranges", "update", id, "--ip-range", updated)
+	out = mustRunCLI(t, "organizations", "sip-ip-ranges", "list")
+	assertContains(t, string(out), updated)
+
+	// Delete
+	mustRunCLI(t, "organizations", "sip-ip-ranges", "delete", id)
+}
+
+// ---------------------------------------------------------------------------
+// Tool History (gated on SYLLABLE_TEST_TOOL_ID — needs an existing tool)
+// ---------------------------------------------------------------------------
+
+func TestToolsHistory(t *testing.T) {
+	toolID := os.Getenv("SYLLABLE_TEST_TOOL_ID")
+	if toolID == "" {
+		t.Skip("SYLLABLE_TEST_TOOL_ID not set; skipping tool history test")
+	}
+	out := mustRunCLI(t, "tools", "history", toolID)
+	assertContains(t, string(out), "items")
+}
+
+// ---------------------------------------------------------------------------
+// Twilio A2P compliance check (gated — needs a Twilio channel + number)
+// ---------------------------------------------------------------------------
+
+func TestChannelsTwilioVerifyA2p(t *testing.T) {
+	channelID := os.Getenv("SYLLABLE_TEST_CHANNEL_ID")
+	phone := os.Getenv("SYLLABLE_TEST_PHONE")
+	if channelID == "" || phone == "" {
+		t.Skip("SYLLABLE_TEST_CHANNEL_ID / SYLLABLE_TEST_PHONE not set; skipping A2P compliance test")
+	}
+	out := mustRunCLI(t, "channels", "twilio", "numbers-verify-a2p-compliance", channelID, "--phone", phone)
+	assertContains(t, string(out), "a2p_approved")
+}


### PR DESCRIPTION
## Stage 1 of the autonomous spec-sync pipeline — make the QA gate real

#86 (the routine's first reconciliation) shipped its new commands with **stubbed unit tests only**. `spec-live-check.yml` confirmed existing commands didn't regress, but it never exercised `agents labels`, `tools history`, the A2P check, or `sip-ip-ranges` against the live API — the PR honestly flagged this. This closes the gap.

### What
- **Backfilled integration tests** for the #86 commands:
  - `TestAgentsLabels` — read-only smoke (live)
  - `TestOrganizationsSipIPRangesCRUD` — create → list → update → delete a TEST-NET-3 CIDR, self-cleaning (live)
  - `TestToolsHistory`, `TestChannelsTwilioVerifyA2p` — gated on env preconditions (an existing tool / a Twilio channel); skip cleanly otherwise
- **Taught the `syllable-sync` skill** to add an integration test for every new command going forward (CRUD cycle / read-only smoke / env-gated), so future reconciliations close their own QA gap.

### Validation
Ran against `cli-test`: `TestAgentsLabels` PASS, `TestOrganizationsSipIPRangesCRUD` PASS (created + cleaned up range id=77), gated tests SKIP. Labeled `spec-sync` so `spec-live-check.yml` runs the full suite — including these — live in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
