### PR TITLE
fix: pure JSON schema output, byte-safe takeouts, context-aware 404 hints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ Quick reference for every resource: what it is, key fields, and hard constraints
 | **Incidents** | Platform incident tracking | name, status | — |
 | **Organizations** | Current organization | display_name, slug, description | API exposes the **current** org only — `get` returns it; `update` modifies it. Create and delete are intentionally not exposed via CLI — use the web console for both. `sip-ip-ranges` (list/create/update/delete) manages signaling & media SIP IP ranges in CIDR notation. |
 | **Permissions** | System-wide permissions | name | Read-only. |
-| **Conversation Config (Bridges)** | Transfer/handoff phrase configuration | phrases | — |
+| **Conversation Config (Bridges)** | Bridge phrases — filler messages spoken during delays and tool calls (Console: Voices → Phrases) | first_slow_messages, very_slow_messages, tool_responses | Supports per-language overrides via `localized`. |
 | **Schema** | Explore API request/response shapes from embedded OpenAPI spec | type name | No API call made. Use before create/update to find required fields. |
 
 ---
@@ -545,7 +545,7 @@ syllable permissions list
 ```
 
 ### Conversation Config
-Configuration for bridging/transfer phrases used when agents hand off to human agents.
+Bridge phrases — the filler messages an agent speaks while it is delayed or a tool call is in progress. This is the feature the Console shows under **Voices → Phrases**. Config fields: `first_slow_messages`, `very_slow_messages`, `tool_responses`, plus per-language overrides under `localized`.
 ```bash
 syllable conversation-config bridges
 syllable conversation-config bridges-update --file bridges.json

--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -2232,3 +2232,108 @@ func min(a, b int) int {
 	}
 	return b
 }
+
+// --- Output purity and hint tests ---
+
+func TestSchemaGetJSONOutputPure(t *testing.T) {
+	prev := viper.GetString("output")
+	defer viper.Set("output", prev)
+
+	// --output json: no markdown heading, stdout must parse as JSON
+	viper.Set("output", "json")
+	cmd := schemaGetCmd()
+	cmd.SetArgs([]string{"AgentCreate"})
+	out := captureStdout(func() {
+		cmd.Execute()
+	})
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Errorf("schema get -o json output is not pure JSON: %v\nfirst bytes: %.40q", err, out)
+	}
+
+	// table (default): heading stays
+	viper.Set("output", "table")
+	cmd = schemaGetCmd()
+	cmd.SetArgs([]string{"AgentCreate"})
+	out = captureStdout(func() {
+		cmd.Execute()
+	})
+	if !strings.HasPrefix(out, "# AgentCreate") {
+		t.Errorf("table output should keep the heading, got: %.40q", out)
+	}
+}
+
+func TestTakeoutsDownloadBytes(t *testing.T) {
+	// Invalid UTF-8 on purpose: takeout files may be binary (audio, archives).
+	payload := []byte{0x50, 0x4b, 0x03, 0x04, 0xff, 0xfe, 0x00, 0x9f}
+	var path string
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		w.Write(payload)
+	})
+	defer server.Close()
+
+	cmd := takeoutsDownloadCmd()
+	cmd.SetArgs([]string{"job-1", "export.zip"})
+	out := captureStdout(func() {
+		cmd.Execute()
+	})
+
+	if path != "/api/v1/takeouts/get/job-1/file/export.zip" {
+		t.Errorf("unexpected path: %s", path)
+	}
+	if !bytes.Equal([]byte(out), payload) {
+		t.Errorf("download not byte-exact: got %x, want %x", out, payload)
+	}
+}
+
+// fakeCommandTree builds syllable → tools → {list, get <tool-name>, update <agent-id>}
+// for hint tests without touching the real rootCmd.
+func fakeCommandTree() (list, getByName, updateByID *cobra.Command) {
+	root := &cobra.Command{Use: "syllable"}
+	parent := &cobra.Command{Use: "tools"}
+	list = &cobra.Command{Use: "list", Run: func(*cobra.Command, []string) {}}
+	getByName = &cobra.Command{Use: "get <tool-name>", Run: func(*cobra.Command, []string) {}}
+	updateByID = &cobra.Command{Use: "update <agent-id>", Run: func(*cobra.Command, []string) {}}
+	parent.AddCommand(list, getByName, updateByID)
+	root.AddCommand(parent)
+	return list, getByName, updateByID
+}
+
+func TestHint404ContextAware(t *testing.T) {
+	list, getByName, updateByID := fakeCommandTree()
+
+	// list itself 404ing → no hint; the API detail says it all (issue #73)
+	if h := hint404(list); h != "" {
+		t.Errorf("404 on list should produce no hint, got %q", h)
+	}
+
+	// name-keyed command → steer to the NAME column, not IDs (issue #69)
+	h := hint404(getByName)
+	if !strings.Contains(h, "name") || !strings.Contains(h, "`syllable tools list`") {
+		t.Errorf("name-keyed 404 hint should mention names and the list command path, got %q", h)
+	}
+
+	// id-keyed command → name the actual list command
+	h = hint404(updateByID)
+	if !strings.Contains(h, "`syllable tools list`") {
+		t.Errorf("id-keyed 404 hint should name the list command path, got %q", h)
+	}
+
+	// nil command (defensive) → generic fallback
+	if h := hint404(nil); !strings.Contains(h, "list") {
+		t.Errorf("nil-command 404 hint should keep the generic fallback, got %q", h)
+	}
+}
+
+func TestHintForErrorThreadsCommand(t *testing.T) {
+	_, getByName, _ := fakeCommandTree()
+	err := &client.APIError{StatusCode: 404, Body: []byte(`{"detail":"Tool with name 425 not found"}`)}
+	h := hintForError(getByName, err)
+	if !strings.Contains(h, "`syllable tools list`") {
+		t.Errorf("hintForError should thread the command into the 404 hint, got %q", h)
+	}
+	if h2 := hintForError(nil, err); h2 == "" {
+		t.Error("hintForError with nil command should still produce a 404 hint")
+	}
+}

--- a/scripts/syllable-cli/cmd/conversation_config.go
+++ b/scripts/syllable-cli/cmd/conversation_config.go
@@ -11,14 +11,20 @@ import (
 func conversationConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "conversation-config",
-		Short: "Manage conversation configuration",
-		Example: `  # Get the current bridge configuration
+		Short: "Manage conversation configuration (bridge phrases)",
+		Long: `Manage conversation configuration.
+
+Bridge phrases — the Console calls these "Voices → Phrases" — are the filler
+messages an agent speaks while it is delayed or a tool call is in progress
+(first_slow_messages, very_slow_messages, tool_responses), with optional
+per-language overrides.`,
+		Example: `  # Get the current bridge phrases configuration
   syllable conversation-config bridges
 
-  # Get bridge configuration as JSON
+  # Get bridge phrases configuration as JSON
   syllable conversation-config bridges --output json
 
-  # Update the bridge configuration from a JSON file
+  # Update the bridge phrases configuration from a JSON file
   syllable conversation-config bridges-update --file bridges.json`,
 	}
 
@@ -31,7 +37,7 @@ func conversationConfigCmd() *cobra.Command {
 func conversationConfigBridgesGetCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "bridges",
-		Short: "Get conversation bridge configuration",
+		Short: "Get bridge phrases configuration (Console: Voices → Phrases)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			data, _, err := apiClient.Get("/api/v1/conversation-config/bridges")
 			if err != nil {
@@ -48,7 +54,7 @@ func conversationConfigBridgesUpdateCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "bridges-update",
-		Short: "Update conversation bridge configuration",
+		Short: "Update bridge phrases configuration (Console: Voices → Phrases)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var body interface{}
 

--- a/scripts/syllable-cli/cmd/root.go
+++ b/scripts/syllable-cli/cmd/root.go
@@ -78,19 +78,20 @@ Feedback: https://github.com/asksyllable/syllable-cli/issues`,
 // Execute runs the root command.
 func Execute() {
 	rootCmd.SilenceErrors = true
-	if err := rootCmd.Execute(); err != nil {
+	cmd, err := rootCmd.ExecuteC()
+	if err != nil {
 		var dryRun *client.DryRunResult
 		if errors.As(err, &dryRun) {
 			output.PrintJSON(dryRun.Output)
 			return
 		}
-		printError(err)
+		printError(cmd, err)
 		os.Exit(1)
 	}
 }
 
-func printError(err error) {
-	hint := hintForError(err)
+func printError(cmd *cobra.Command, err error) {
+	hint := hintForError(cmd, err)
 	if getOutputFmt() == "json" {
 		var apiErr *client.APIError
 		if errors.As(err, &apiErr) {
@@ -122,8 +123,9 @@ func printError(err error) {
 	}
 }
 
-// hintForError returns an actionable suggestion for common errors.
-func hintForError(err error) string {
+// hintForError returns an actionable suggestion for common errors. cmd is the
+// command that failed, used to tailor hints; it may be nil.
+func hintForError(cmd *cobra.Command, err error) string {
 	// Non-API errors: missing required flags
 	msg := err.Error()
 	if strings.Contains(msg, "required flags") || strings.Contains(msg, "use --file") {
@@ -141,13 +143,60 @@ func hintForError(err error) string {
 	case 403:
 		return "You don't have permission for this action. Check: syllable permissions list"
 	case 404:
-		return "Resource not found. Use the `list` subcommand to find valid IDs."
+		return hint404(cmd)
 	case 409:
+		if listPath := siblingListPath(cmd); listPath != "" {
+			return fmt.Sprintf("A resource with this name already exists. Use `%s` to find it.", listPath)
+		}
 		return "A resource with this name already exists. Use the `list` subcommand to find it."
 	case 422, 400:
 		return hint422(apiErr.Body)
 	case 500, 502, 503, 504:
 		return "Server error. This may be temporary — try again shortly."
+	}
+	return ""
+}
+
+// hint404 builds a 404 hint aware of which command failed. A 404 from `list`
+// means the org genuinely has nothing configured — pointing the user at `list`
+// would be a wild goose chase, so the API's own detail message stands alone.
+// Name-keyed commands (`get <tool-name>`, `update <user-email>`) steer users to
+// the right column instead of blaming an ID.
+func hint404(cmd *cobra.Command) string {
+	if cmd == nil {
+		return "Resource not found. Use the `list` subcommand to find valid IDs."
+	}
+	if cmd.Name() == "list" {
+		return ""
+	}
+	listPath := siblingListPath(cmd)
+	switch {
+	case strings.Contains(cmd.Use, "-name>"):
+		if listPath != "" {
+			return fmt.Sprintf("This command takes a name, not a numeric ID — copy the NAME column from `%s`.", listPath)
+		}
+		return "This command takes a name, not a numeric ID."
+	case strings.Contains(cmd.Use, "-email>"):
+		if listPath != "" {
+			return fmt.Sprintf("This command takes an email address — copy the EMAIL column from `%s`.", listPath)
+		}
+		return "This command takes an email address, not a numeric ID."
+	case listPath != "":
+		return fmt.Sprintf("Resource not found. Use `%s` to find valid IDs.", listPath)
+	}
+	return "Resource not found. Use the `list` subcommand to find valid IDs."
+}
+
+// siblingListPath returns the full command path of the `list` sibling of cmd
+// (e.g. "syllable tools list"), or "" when cmd has no list sibling.
+func siblingListPath(cmd *cobra.Command) string {
+	if cmd == nil || cmd.Parent() == nil {
+		return ""
+	}
+	for _, sib := range cmd.Parent().Commands() {
+		if sib.Name() == "list" {
+			return sib.CommandPath()
+		}
 	}
 	return ""
 }

--- a/scripts/syllable-cli/cmd/schema.go
+++ b/scripts/syllable-cli/cmd/schema.go
@@ -108,7 +108,11 @@ func schemaGetCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Printf("# %s\n\n", name)
+			// Heading is decoration for humans; suppress it under --output json
+			// so the output stays pipeable to jq.
+			if getOutputFmt() != "json" {
+				fmt.Printf("# %s\n\n", name)
+			}
 			output.PrintJSON(b)
 			return nil
 		},

--- a/scripts/syllable-cli/cmd/takeouts.go
+++ b/scripts/syllable-cli/cmd/takeouts.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -95,8 +96,9 @@ func takeoutsDownloadCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Print(string(data))
-			return nil
+			// Byte-safe write: takeout files may be binary (audio, archives).
+			_, err = os.Stdout.Write(data)
+			return err
 		},
 	}
 }


### PR DESCRIPTION
Three small UX/correctness fixes from the v1.5.1 QA batch, plus a discoverability fix.

## What changed

- **`schema get -o json` is now pure JSON** — the markdown `# Heading` is suppressed under `--output json`, so `syllable schema get AgentCreate -o json | jq .` works. Table output keeps the heading. Closes #72.
- **`takeouts download` writes bytes** — `fmt.Print(string(data))` → `os.Stdout.Write(data)`, matching `directory download` and `pronunciations get-csv` (the other two commands named in the issue were already fixed). Takeout files may be binary. Closes #55.
- **404/409 hints are context-aware** — `Execute()` now uses Cobra's `ExecuteC()` to learn which command failed:
  - a 404 from a `list` command produces **no** hint (the API's own detail, e.g. *"No pronunciation dictionary found for this organization"*, says it all — no more wild goose chase);
  - other commands get the real path: ``Use `syllable tools list` to find valid IDs``;
  - name/email-keyed commands (`get <tool-name>`, `update <user-email>`) steer users to the NAME/EMAIL column instead of blaming an ID — the hint half of #69 (the accept-IDs half lands separately).
  Closes #73.
- **Bridge phrases are findable** — `conversation-config` help and AGENTS.md now say "bridge phrases" and cross-reference the Console's **Voices → Phrases** page. The old AGENTS.md text mischaracterized bridges as *transfer/handoff* phrases, which is likely why #82 was filed against a feature the CLI already has.

## Tests

- `TestSchemaGetJSONOutputPure` — json output parses; table keeps heading
- `TestTakeoutsDownloadBytes` — byte-exact round-trip of invalid-UTF-8 payload
- `TestHint404ContextAware` / `TestHintForErrorThreadsCommand` — list-no-hint, name-keyed, id-keyed, nil-command cases

`go test ./...` green locally; smoke-tested `schema get | jq` and help output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)