### PR TITLE
fix: update commands honor the positional resource ID

### DIFF
--- a/scripts/syllable-cli/cmd/agents.go
+++ b/scripts/syllable-cli/cmd/agents.go
@@ -308,6 +308,11 @@ func agentsUpdateCmd() *cobra.Command {
 				return fmt.Errorf("use --file to provide update body")
 			}
 
+			// The API routes this PUT by the id inside the body (#68).
+			if err := ensureBodyIdentifier(body, "id", args[0], true); err != nil {
+				return err
+			}
+
 			data, _, err := apiClient.Put("/api/v1/agents/", body)
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -2335,5 +2336,166 @@ func TestHintForErrorThreadsCommand(t *testing.T) {
 	}
 	if h2 := hintForError(nil, err); h2 == "" {
 		t.Error("hintForError with nil command should still produce a 404 hint")
+	}
+}
+
+// --- Update positional identifier tests (#68) ---
+
+func writeTempJSON(t *testing.T, content string) string {
+	t.Helper()
+	f := filepath.Join(t.TempDir(), "body.json")
+	if err := os.WriteFile(f, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+func TestEnsureBodyIdentifier(t *testing.T) {
+	// inject numeric id when absent
+	body := map[string]interface{}{"description": "x"}
+	if err := ensureBodyIdentifier(body, "id", "574", true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if body["id"] != int64(574) {
+		t.Errorf("expected injected id 574, got %#v", body["id"])
+	}
+
+	// matching body id passes (encoding/json decodes numbers as float64)
+	if err := ensureBodyIdentifier(map[string]interface{}{"id": float64(574)}, "id", "574", true); err != nil {
+		t.Errorf("matching id should pass: %v", err)
+	}
+
+	// conflicting body id is refused
+	if err := ensureBodyIdentifier(map[string]interface{}{"id": float64(575)}, "id", "574", true); err == nil {
+		t.Error("conflicting id should error")
+	}
+
+	// non-numeric positional for a numeric key is refused
+	if err := ensureBodyIdentifier(map[string]interface{}{}, "id", "abc", true); err == nil {
+		t.Error("non-numeric id should error")
+	}
+
+	// string keys inject as strings (users email, tools name)
+	body = map[string]interface{}{}
+	if err := ensureBodyIdentifier(body, "email", "a@b.co", false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if body["email"] != "a@b.co" {
+		t.Errorf("expected injected email, got %#v", body["email"])
+	}
+
+	// conflicting string identifier is refused
+	if err := ensureBodyIdentifier(map[string]interface{}{"name": "other_tool"}, "name", "my_tool", false); err == nil {
+		t.Error("conflicting name should error")
+	}
+
+	// non-object bodies pass through untouched
+	if err := ensureBodyIdentifier([]interface{}{"x"}, "id", "574", true); err != nil {
+		t.Errorf("non-object body should be a no-op: %v", err)
+	}
+}
+
+func TestAgentsUpdateInjectsPositionalID(t *testing.T) {
+	var method, path string
+	var got map[string]interface{}
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		path = r.URL.Path
+		json.NewDecoder(r.Body).Decode(&got)
+		w.Write([]byte(`{}`))
+	})
+	defer server.Close()
+
+	cmd := agentsUpdateCmd()
+	cmd.SetArgs([]string{"574", "--file", writeTempJSON(t, `{"description":"noop"}`)})
+	captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	if method != "PUT" || path != "/api/v1/agents/" {
+		t.Errorf("unexpected request: %s %s", method, path)
+	}
+	if got["id"] != float64(574) {
+		t.Errorf("expected body id 574, got %#v", got["id"])
+	}
+	if got["description"] != "noop" {
+		t.Errorf("body fields should survive injection, got %#v", got)
+	}
+}
+
+func TestAgentsUpdateConflictingBodyID(t *testing.T) {
+	hit := false
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+	})
+	defer server.Close()
+
+	cmd := agentsUpdateCmd()
+	cmd.SetArgs([]string{"574", "--file", writeTempJSON(t, `{"id": 575}`)})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	var err error
+	captureStdout(func() { err = cmd.Execute() })
+
+	if err == nil || !strings.Contains(err.Error(), "conflicts") {
+		t.Errorf("expected conflict error, got %v", err)
+	}
+	if hit {
+		t.Error("request should not reach the API on identifier conflict")
+	}
+}
+
+func TestUsersUpdateInjectsPositionalEmail(t *testing.T) {
+	var got map[string]interface{}
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&got)
+		w.Write([]byte(`{}`))
+	})
+	defer server.Close()
+
+	cmd := usersUpdateCmd()
+	cmd.SetArgs([]string{"a@b.co", "--file", writeTempJSON(t, `{"role_id": 2}`)})
+	captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	if got["email"] != "a@b.co" {
+		t.Errorf("expected injected email, got %#v", got["email"])
+	}
+}
+
+func TestToolsUpdateValidatesPositionalName(t *testing.T) {
+	var got map[string]interface{}
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&got)
+		w.Write([]byte(`{}`))
+	})
+	defer server.Close()
+
+	// name absent from body → injected from the positional
+	cmd := toolsUpdateCmd()
+	cmd.SetArgs([]string{"my_tool", "--file", writeTempJSON(t, `{"id": 425, "service_id": 1}`)})
+	captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+	if got["name"] != "my_tool" {
+		t.Errorf("expected injected name, got %#v", got["name"])
+	}
+
+	// conflicting name in body → refused
+	cmd = toolsUpdateCmd()
+	cmd.SetArgs([]string{"my_tool", "--file", writeTempJSON(t, `{"id": 425, "name": "other_tool"}`)})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	var err error
+	captureStdout(func() { err = cmd.Execute() })
+	if err == nil || !strings.Contains(err.Error(), "conflicts") {
+		t.Errorf("expected conflict error, got %v", err)
 	}
 }

--- a/scripts/syllable-cli/cmd/custom_messages.go
+++ b/scripts/syllable-cli/cmd/custom_messages.go
@@ -228,6 +228,11 @@ func customMessagesUpdateCmd() *cobra.Command {
 				return fmt.Errorf("use --file to provide update body")
 			}
 
+			// The API routes this PUT by the id inside the body (#68).
+			if err := ensureBodyIdentifier(body, "id", args[0], true); err != nil {
+				return err
+			}
+
 			data, _, err := apiClient.Put("/api/v1/custom_messages/", body)
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/language_groups.go
+++ b/scripts/syllable-cli/cmd/language_groups.go
@@ -211,6 +211,11 @@ func languageGroupsUpdateCmd() *cobra.Command {
 				return fmt.Errorf("use --file to provide update body")
 			}
 
+			// The API routes this PUT by the id inside the body (#68).
+			if err := ensureBodyIdentifier(body, "id", args[0], true); err != nil {
+				return err
+			}
+
 			data, _, err := apiClient.Put("/api/v1/language_groups/", body)
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/prompts.go
+++ b/scripts/syllable-cli/cmd/prompts.go
@@ -227,6 +227,11 @@ func promptsUpdateCmd() *cobra.Command {
 				return fmt.Errorf("use --file to provide update body")
 			}
 
+			// The API routes this PUT by the id inside the body (#68).
+			if err := ensureBodyIdentifier(body, "id", args[0], true); err != nil {
+				return err
+			}
+
 			data, _, err := apiClient.Put("/api/v1/prompts/", body)
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/root.go
+++ b/scripts/syllable-cli/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -430,6 +431,53 @@ func readFile(path string) ([]byte, error) {
 		return io.ReadAll(os.Stdin)
 	}
 	return os.ReadFile(path)
+}
+
+// ensureBodyIdentifier reconciles an update command's positional identifier
+// with its --file body. The platform's collection-style PUT endpoints (e.g.
+// PUT /api/v1/agents/) route by an identifier field inside the body, not the
+// URL — without this guard the positional arg is accepted but ignored, and the
+// body's value silently decides which resource gets updated (#68).
+//
+// When the body lacks key, the positional value is injected (as a JSON number
+// when numeric is true). When the body carries a conflicting value, the update
+// is refused rather than guessing which resource the user meant.
+func ensureBodyIdentifier(body interface{}, key, positional string, numeric bool) error {
+	m, ok := body.(map[string]interface{})
+	if !ok {
+		// Non-object bodies cannot carry the identifier; let the API validate.
+		return nil
+	}
+	if existing, ok := m[key]; ok && existing != nil {
+		if !identifierMatches(existing, positional) {
+			return fmt.Errorf("positional argument %q conflicts with %s=%v in the request body — make them match or drop %s from the body", positional, key, existing, key)
+		}
+		return nil
+	}
+	if numeric {
+		n, err := strconv.ParseInt(positional, 10, 64)
+		if err != nil {
+			return fmt.Errorf("expected a numeric identifier, got %q", positional)
+		}
+		m[key] = n
+		return nil
+	}
+	m[key] = positional
+	return nil
+}
+
+// identifierMatches compares a JSON body value against a positional CLI string.
+func identifierMatches(existing interface{}, positional string) bool {
+	switch v := existing.(type) {
+	case string:
+		return v == positional
+	case float64: // encoding/json decodes JSON numbers to float64
+		p, err := strconv.ParseFloat(positional, 64)
+		return err == nil && p == v
+	case json.Number:
+		return v.String() == positional
+	}
+	return false
 }
 
 // printTable prints a table, applying --fields column filtering if set.

--- a/scripts/syllable-cli/cmd/tools.go
+++ b/scripts/syllable-cli/cmd/tools.go
@@ -283,6 +283,12 @@ func toolsUpdateCmd() *cobra.Command {
 				return fmt.Errorf("use --file to provide update body")
 			}
 
+			// The positional is the tool name; the API routes this PUT by the
+			// body's numeric id, so the name is validated/injected only (#68).
+			if err := ensureBodyIdentifier(body, "name", args[0], false); err != nil {
+				return err
+			}
+
 			data, _, err := apiClient.Put("/api/v1/tools/", body)
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/users.go
+++ b/scripts/syllable-cli/cmd/users.go
@@ -295,6 +295,11 @@ func usersUpdateCmd() *cobra.Command {
 				return fmt.Errorf("use --file to provide update body")
 			}
 
+			// The API routes this PUT by the email inside the body (#68).
+			if err := ensureBodyIdentifier(body, "email", args[0], false); err != nil {
+				return err
+			}
+
 			data, _, err := apiClient.Put("/api/v1/users/", body)
 			if err != nil {
 				return err


### PR DESCRIPTION
## The bug was worse than the issue title

#68 reported `--dry-run` printing a PUT URL without the resource ID. Root cause: the API's update endpoints are collection-style (`PUT /api/v1/agents/`) and route by the **identifier inside the body** — and the six body-routed update commands accepted a positional ID **without ever reading it**. `syllable agents update 574 --file body.json` updated whatever `id` the body contained; 574 was decoration. It worked daily only because the canonical `get → jq → update` pipe carries the right `id` in the body.

## The fix

A shared guard, `ensureBodyIdentifier` (cmd/root.go), applied to all six body-routed update commands:

| Command | Positional → body key |
|---|---|
| `agents update` | `id` (numeric) |
| `prompts update` | `id` (numeric) |
| `custom-messages update` | `id` (numeric) |
| `language-groups update` | `id` (numeric) |
| `users update` | `email` |
| `tools update` | `name` (body still routes by its numeric `id`; the name is validated/injected) |

- Body lacks the key → positional is injected (as a JSON number where the schema says integer).
- Body carries a **different** value → hard error naming both; never silently prefer either:
  ```
  Error: positional argument "574" conflicts with id=575 in the request body — make them match or drop id from the body
  ```
- `--dry-run` previews now show the effective identifier in the body (the URL stays collection-style — that is genuinely what the API expects):
  ```json
  { "body": { "description": "noop", "id": 574 }, "dry_run": true, "method": "PUT", "url": ".../api/v1/agents/" }
  ```

Commands whose updates already embed the ID in the URL (outbound, insights, directory, channels) were audited and are unaffected; body-only update commands (roles, services, data-sources, voice-groups, incidents) keep their existing contract.

## Tests

- `TestEnsureBodyIdentifier` — inject/match/conflict/non-numeric/string-key/non-object cases
- `TestAgentsUpdateInjectsPositionalID` — stub server receives `id: 574` merged into the body
- `TestAgentsUpdateConflictingBodyID` — conflict errors **before** any request is sent
- `TestUsersUpdateInjectsPositionalEmail`, `TestToolsUpdateValidatesPositionalName`

`go test ./...` green locally.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)