### PR TITLE
fix: users me fails loudly without email; warn on ignored override-timestamp forms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Quick reference for every resource: what it is, key fields, and hard constraints
 | **Custom Messages** | Opening greetings for agents | name, text | Configured per agent. |
 | **Voice Groups** | Voice configuration for agents | name, voices | Replaces language groups. |
 | **Language Groups** | Voice configuration (deprecated) | name | **DEPRECATED — use voice-groups instead.** |
-| **Users** | Platform accounts | email, role_id, first_name, last_name | `users me` returns the current authenticated user. |
+| **Users** | Platform accounts | email, role_id, first_name, last_name | `users me` looks up the email configured in `syllable setup`; it errors if no email is set (the API has no key-identity endpoint). |
 | **Directory** | Member/contact list for call routing and transfers | name, type, phone | Used by agents at runtime for transfer targets and contact lookups. |
 | **Roles** | User roles with associated permissions | name, permissions | — |
 | **Pronunciations** | Custom TTS pronunciation dictionary | word, pronunciation | Downloadable as CSV. |

--- a/scripts/syllable-cli/cmd/agents.go
+++ b/scripts/syllable-cli/cmd/agents.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -389,6 +391,9 @@ the same --test-id).`,
 				body["text"] = ""
 			}
 			if cmd.Flags().Changed("override-timestamp") {
+				if w := overrideTimestampWarning(overrideTimestamp); w != "" {
+					fmt.Fprintln(cmd.ErrOrStderr(), w)
+				}
 				body["override_timestamp"] = overrideTimestamp
 			}
 
@@ -438,4 +443,32 @@ the same --test-id).`,
 	_ = cmd.MarkFlagRequired("test-id")
 
 	return cmd
+}
+
+// timestampOffsetRe matches a trailing ±HH:MM timezone offset (after the time —
+// date dashes never match because an offset requires a colon).
+var timestampOffsetRe = regexp.MustCompile(`[+-][0-9]{2}:[0-9]{2}$`)
+
+// overrideTimestampWarning returns a non-empty warning when ts carries a
+// signal the conversation-test server is confirmed to silently ignore: a
+// trailing Z, a ±HH:MM offset, or a space instead of the 'T' separator. The
+// flag still sends the value (warn, don't block) — a hard rejection would
+// break the thin-passthrough contract and become wrong once the server
+// accepts tz-aware values. Negative checks only: a positive validator would
+// false-positive on forms not confirmed either way (#77). Remove once
+// ZOO-7814 lands server-side — the spec-drift workflow will flag the
+// TestMessage.override_timestamp schema change.
+func overrideTimestampWarning(ts string) string {
+	var reason string
+	switch {
+	case strings.HasSuffix(ts, "Z") || strings.HasSuffix(ts, "z"):
+		reason = "ends in 'Z' (UTC designator)"
+	case timestampOffsetRe.MatchString(ts):
+		reason = "carries a timezone offset"
+	case strings.Contains(ts, " ") && !strings.Contains(ts, "T"):
+		reason = "uses a space instead of the 'T' separator"
+	default:
+		return ""
+	}
+	return fmt.Sprintf("warning: --override-timestamp %q %s; the server only honors timezone-naive ISO 8601 (e.g. 2030-12-25T09:30:00) and will silently ignore this value, falling back to the real clock", ts, reason)
 }

--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -2499,3 +2499,107 @@ func TestToolsUpdateValidatesPositionalName(t *testing.T) {
 		t.Errorf("expected conflict error, got %v", err)
 	}
 }
+
+// --- No-silent-wrong-answers tests (#71, #77) ---
+
+func TestUsersMeNoEmailFailsLoudly(t *testing.T) {
+	hit := false
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+	})
+	defer server.Close()
+
+	prev := viper.GetString("email")
+	defer viper.Set("email", prev)
+	viper.Set("email", "")
+
+	cmd := usersMeCmd()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	var err error
+	captureStdout(func() { err = cmd.Execute() })
+
+	if err == nil || !strings.Contains(err.Error(), "syllable setup") {
+		t.Errorf("expected loud failure pointing at setup, got %v", err)
+	}
+	if hit {
+		t.Error("no request should be made when email is unconfigured")
+	}
+}
+
+func TestUsersMeWithEmailLooksUpExactUser(t *testing.T) {
+	var path string
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		w.Write([]byte(`{"id": 1, "email": "josh@syllable.ai"}`))
+	})
+	defer server.Close()
+
+	prev := viper.GetString("email")
+	defer viper.Set("email", prev)
+	viper.Set("email", "josh@syllable.ai")
+
+	cmd := usersMeCmd()
+	captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	if path != "/api/v1/users/josh@syllable.ai" {
+		t.Errorf("expected exact email lookup, got %s", path)
+	}
+}
+
+func TestOverrideTimestampWarning(t *testing.T) {
+	cases := []struct {
+		ts   string
+		warn bool
+	}{
+		{"2030-12-25T09:30:00", false},        // the honored tz-naive form
+		{"2030-12-25T09:30:00.123456", false}, // unconfirmed → no warning (negative checks only)
+		{"not-a-real-timestamp", false},       // documented limitation: pure garbage passes silently
+		{"2030-12-25", false},                 // date dashes are not an offset
+		{"2030-12-25T09:30:00Z", true},        // UTC designator
+		{"2030-12-25T09:30:00z", true},        // lowercase z
+		{"2030-12-25T09:30:00-07:00", true},   // negative offset
+		{"2030-12-25T09:30:00+05:30", true},   // positive offset
+		{"2030-12-25 09:30:00", true},         // space separator
+	}
+	for _, c := range cases {
+		got := overrideTimestampWarning(c.ts)
+		if c.warn && got == "" {
+			t.Errorf("%q should warn", c.ts)
+		}
+		if !c.warn && got != "" {
+			t.Errorf("%q should not warn, got %q", c.ts, got)
+		}
+	}
+}
+
+func TestSendTestMessageWarnsButStillSends(t *testing.T) {
+	var got map[string]interface{}
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&got)
+		w.Write([]byte(`{}`))
+	})
+	defer server.Close()
+
+	cmd := agentsSendTestMessageCmd()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"42", "--test-id", "t1", "--override-timestamp", "2030-12-25T09:30:00Z"})
+	captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(stderr.String(), "warning: --override-timestamp") {
+		t.Errorf("expected stderr warning, got %q", stderr.String())
+	}
+	// Warn, don't block: the value is still sent unchanged.
+	if got["override_timestamp"] != "2030-12-25T09:30:00Z" {
+		t.Errorf("value should still be sent unchanged, got %#v", got["override_timestamp"])
+	}
+}

--- a/scripts/syllable-cli/cmd/users.go
+++ b/scripts/syllable-cli/cmd/users.go
@@ -393,59 +393,11 @@ func usersMeCmd() *cobra.Command {
 				return nil
 			}
 
-			// No email configured — fall back to listing users and taking the first result.
-			// Configure your email in `syllable setup` for a more accurate result.
-			data, _, err := apiClient.Get("/api/v1/users/?limit=1")
-			if err != nil {
-				return err
-			}
-
-			if getOutputFmt() == "json" {
-				output.PrintJSON(data)
-				return nil
-			}
-
-			var result struct {
-				Items []struct {
-					ID             json.Number `json:"id"`
-					Email          string      `json:"email"`
-					FirstName      *string     `json:"first_name"`
-					LastName       *string     `json:"last_name"`
-					RoleName       string      `json:"role_name"`
-					ActivityStatus string      `json:"activity_status"`
-					LastUpdated    string      `json:"last_updated"`
-					LastSessionAt  string      `json:"last_session_at"`
-				} `json:"items"`
-			}
-			if err := json.Unmarshal(data, &result); err != nil || len(result.Items) == 0 {
-				output.PrintJSON(data)
-				return nil
-			}
-
-			u := result.Items[0]
-			name := ""
-			if u.FirstName != nil {
-				name = *u.FirstName
-			}
-			if u.LastName != nil {
-				if name != "" {
-					name += " "
-				}
-				name += *u.LastName
-			}
-
-			fmt.Fprintln(cmd.ErrOrStderr(), "Hint: configure your email in `syllable setup` for an exact lookup.")
-			rows := [][]string{
-				{"ID", u.ID.String()},
-				{"Email", u.Email},
-				{"Name", name},
-				{"Role", u.RoleName},
-				{"Status", u.ActivityStatus},
-				{"Last Updated", u.LastUpdated},
-				{"Last Session", u.LastSessionAt},
-			}
-			printTable([]string{"FIELD", "VALUE"}, rows)
-			return nil
+			// No email configured. The API has no identity endpoint (nothing
+			// maps an API key to its owner), so any fallback would return an
+			// arbitrary user — worse than failing, because callers build on
+			// the answer ("I'm Admin → writes will work") (#71).
+			return fmt.Errorf("no email configured — run `syllable setup` and set your email so `users me` can look up your account")
 		},
 	}
 }


### PR DESCRIPTION
Two fixes with the same theme: never give a silently wrong answer.

## `users me` (#71)

Without a configured email, the command fetched `/api/v1/users/?limit=1` and presented the **first user in the org** as "me" — with only a stderr hint that the lookup was approximate. Anyone scripting "what role does my key have" could build on another user's account.

The API offers no identity endpoint (nothing maps an API key to its owner — see the triage note on the issue), so there is no correct fallback. The command now fails loudly:

```
$ syllable users me
Error: no email configured — run `syllable setup` and set your email so `users me` can look up your account
(exit 1)
```

The email-configured exact-lookup path is unchanged. AGENTS.md updated to match.

## `--override-timestamp` (#77)

The conversation-test server honors only timezone-naive ISO 8601; offset/`Z`/space-separated forms are **silently dropped** (HTTP 200, real wall clock). Per the issue's design notes this adds a **stderr warning on the three confirmed-ignored signals only** — trailing `Z`, `±HH:MM` offset, space separator — and still sends the value (warn, don't block; a hard error would break the passthrough contract and become wrong once the server accepts tz-aware values):

```
warning: --override-timestamp "2030-12-25T09:30:00Z" ends in 'Z' (UTC designator); the server only honors timezone-naive ISO 8601 (e.g. 2030-12-25T09:30:00) and will silently ignore this value, falling back to the real clock
```

Stderr keeps `--output json` stdout clean, and the warning also fires under `--dry-run` for preflighting. Code comment marks it for removal when ZOO-7814 lands server-side — the spec-drift workflow will flag the `TestMessage.override_timestamp` schema change as the cue.

## Tests

- `TestUsersMeNoEmailFailsLoudly` — errors before any request; message names `syllable setup`
- `TestUsersMeWithEmailLooksUpExactUser` — exact-lookup path unchanged
- `TestOverrideTimestampWarning` — table-driven: honored/unconfirmed/garbage forms stay silent; Z/z/±offset/space warn
- `TestSendTestMessageWarnsButStillSends` — warning on stderr, value sent unchanged

`go test ./...` green locally.

Closes #71
Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)