### PR TITLE
feat: tools get accepts numeric IDs; add channels get

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,6 +265,7 @@ syllable agents send-test-message <agent-id> --test-id ID [--session-start] [--t
 Channels define communication modes (voice, SMS, chat). Targets are the specific phone number or chat ID where an agent operates. **Constraint: 1:1 agent-to-target.** Twilio channels configurable via CLI; other channels via SDK.
 ```bash
 syllable channels list [--page N] [--limit N] [--search TEXT]
+syllable channels get <channel-id>   # resolved via the list endpoint (the API has no by-ID GET)
 syllable channels create --file channel.json
 syllable channels create --name NAME --service SERVICE
 syllable channels update <channel-id> --file channel.json
@@ -315,7 +316,7 @@ syllable prompts supported-llms
 APIs agents call during sessions. Requires a Service for auth. Three types: agent tools (called during user sessions), step tools (structured multi-step workflows), system tools (pre-built: `hangup`, `transfer`, `web_search`, `summary-tool`). Dynamic variables use `{{ vars.field }}` syntax.
 ```bash
 syllable tools list [--page N] [--limit N] [--search TEXT]
-syllable tools get <tool-name>
+syllable tools get <tool-name>       # numeric IDs from the list's ID column are resolved to the name
 syllable tools create --file tool.json
 syllable tools create --name NAME --service-id ID
 syllable tools update <tool-name> --file tool.json

--- a/scripts/syllable-cli/cmd/channels.go
+++ b/scripts/syllable-cli/cmd/channels.go
@@ -17,6 +17,9 @@ func channelsCmd() *cobra.Command {
 		Example: `  # List all channels
   syllable channels list
 
+  # Get a single channel by ID
+  syllable channels get 5
+
   # Search channels by name
   syllable channels list --search "support"
 
@@ -46,6 +49,7 @@ func channelsCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(channelsListCmd())
+	cmd.AddCommand(channelsGetCmd())
 	cmd.AddCommand(channelsCreateCmd())
 	cmd.AddCommand(channelsUpdateCmd())
 	cmd.AddCommand(channelsDeleteCmd())
@@ -54,6 +58,75 @@ func channelsCmd() *cobra.Command {
 	cmd.AddCommand(channelsTwilioCmd())
 
 	return cmd
+}
+
+func channelsGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <channel-id>",
+		Short: "Get a channel by ID",
+		Long: `Get a single channel by ID.
+
+The API has no by-ID GET endpoint for channels (#70), so this resolves the
+channel via the list endpoint's id search and prints the matching item — the
+same shape as a single item from ` + "`channels list -o json`" + `.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := "/api/v1/channels/?page=0&limit=100&search_fields=id&search_field_values=" + url.QueryEscape(args[0])
+			data, _, err := apiClient.Get(path)
+			if err != nil {
+				return err
+			}
+
+			var result struct {
+				Items []json.RawMessage `json:"items"`
+			}
+			if err := json.Unmarshal(data, &result); err != nil {
+				return fmt.Errorf("parsing channels list response: %w", err)
+			}
+			// Exact client-side match in case the server searches by substring.
+			var match json.RawMessage
+			for _, raw := range result.Items {
+				var probe struct {
+					ID json.Number `json:"id"`
+				}
+				if json.Unmarshal(raw, &probe) == nil && probe.ID.String() == args[0] {
+					match = raw
+					break
+				}
+			}
+			if match == nil {
+				return fmt.Errorf("channel %s not found — run `syllable channels list` to see available channels", args[0])
+			}
+
+			if getOutputFmt() == "json" {
+				output.PrintJSON(match)
+				return nil
+			}
+
+			var c struct {
+				ID             json.Number `json:"id"`
+				Name           string      `json:"name"`
+				ChannelService string      `json:"channel_service"`
+				IsSystem       bool        `json:"is_system_channel"`
+			}
+			if err := json.Unmarshal(match, &c); err != nil {
+				output.PrintJSON(match)
+				return nil
+			}
+			isSystem := "no"
+			if c.IsSystem {
+				isSystem = "yes"
+			}
+			rows := [][]string{
+				{"ID", c.ID.String()},
+				{"Name", c.Name},
+				{"Service", c.ChannelService},
+				{"Is System", isSystem},
+			}
+			printTable([]string{"FIELD", "VALUE"}, rows)
+			return nil
+		},
+	}
 }
 
 func channelsListCmd() *cobra.Command {

--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -2601,5 +2602,130 @@ func TestSendTestMessageWarnsButStillSends(t *testing.T) {
 	// Warn, don't block: the value is still sent unchanged.
 	if got["override_timestamp"] != "2030-12-25T09:30:00Z" {
 		t.Errorf("value should still be sent unchanged, got %#v", got["override_timestamp"])
+	}
+}
+
+// --- tools get ID fallback and channels get tests (#69, #70) ---
+
+func TestToolsGetByNumericIDFallback(t *testing.T) {
+	var paths []string
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		switch {
+		case r.URL.Path == "/api/v1/tools/425":
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"detail":"Tool with name 425 not found"}`))
+		case r.URL.Path == "/api/v1/tools/" && r.URL.Query().Get("search_fields") == "id":
+			w.Write([]byte(`{"items":[{"id":425,"name":"ability_info"}],"total_count":1}`))
+		case r.URL.Path == "/api/v1/tools/ability_info":
+			w.Write([]byte(`{"id":425,"name":"ability_info","service_name":"pokeapi-v2","service_id":1}`))
+		default:
+			t.Errorf("unexpected request: %s", r.URL.String())
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer server.Close()
+
+	cmd := toolsGetCmd()
+	cmd.SetArgs([]string{"425"})
+	out := captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	if len(paths) != 3 {
+		t.Errorf("expected name-miss → id-resolve → name-get, got %v", paths)
+	}
+	if !strings.Contains(out, "ability_info") {
+		t.Errorf("expected resolved tool in output, got %q", out)
+	}
+}
+
+func TestToolsGetByNameSingleRequest(t *testing.T) {
+	var count int
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		count++
+		w.Write([]byte(`{"id":425,"name":"ability_info","service_name":"pokeapi-v2","service_id":1}`))
+	})
+	defer server.Close()
+
+	cmd := toolsGetCmd()
+	cmd.SetArgs([]string{"ability_info"})
+	captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	if count != 1 {
+		t.Errorf("by-name get should hit the API once, got %d", count)
+	}
+}
+
+func TestToolsGetUnknownIDKeepsOriginal404(t *testing.T) {
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/tools/" {
+			w.Write([]byte(`{"items":[],"total_count":0}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"detail":"Tool with name 999 not found"}`))
+	})
+	defer server.Close()
+
+	cmd := toolsGetCmd()
+	cmd.SetArgs([]string{"999"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	var err error
+	captureStdout(func() { err = cmd.Execute() })
+
+	var apiErr *client.APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != 404 {
+		t.Errorf("expected the original 404 to surface, got %v", err)
+	}
+}
+
+func TestChannelsGet(t *testing.T) {
+	var query string
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		query = r.URL.RawQuery
+		// Substring-style result on purpose: ids 4 and 40 — exact match must win.
+		w.Write([]byte(`{"items":[{"id":40,"name":"other","channel_service":"twilio","is_system_channel":false},{"id":4,"name":"main-voice","channel_service":"twilio","is_system_channel":true}],"total_count":2}`))
+	})
+	defer server.Close()
+
+	cmd := channelsGetCmd()
+	cmd.SetArgs([]string{"4"})
+	out := captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(query, "search_fields=id") {
+		t.Errorf("expected id search in query, got %q", query)
+	}
+	if !strings.Contains(out, "main-voice") || strings.Contains(out, "other") {
+		t.Errorf("expected exactly the id-4 channel, got %q", out)
+	}
+}
+
+func TestChannelsGetNotFound(t *testing.T) {
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"items":[],"total_count":0}`))
+	})
+	defer server.Close()
+
+	cmd := channelsGetCmd()
+	cmd.SetArgs([]string{"77"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	var err error
+	captureStdout(func() { err = cmd.Execute() })
+
+	if err == nil || !strings.Contains(err.Error(), "syllable channels list") {
+		t.Errorf("expected not-found error pointing at channels list, got %v", err)
 	}
 }

--- a/scripts/syllable-cli/cmd/tools.go
+++ b/scripts/syllable-cli/cmd/tools.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 
 	"github.com/spf13/cobra"
+	"github.com/asksyllable/syllable-cli/internal/client"
 	"github.com/asksyllable/syllable-cli/internal/output"
 )
 
@@ -17,17 +19,20 @@ func toolsCmd() *cobra.Command {
 		Example: `  # List all tools
   syllable tools list
 
-  # Get a tool as JSON (inspect full config)
-  syllable tools get 5 --output json
+  # Get a tool as JSON (inspect full config) — tools are name-keyed
+  syllable tools get my_tool --output json
+
+  # Numeric IDs from the list's ID column are resolved to the tool's name
+  syllable tools get 425
 
   # Create a tool from a JSON file
   syllable tools create --file tool.json
 
   # Update a tool
-  syllable tools update 5 --file tool.json
+  syllable tools update my_tool --file tool.json
 
   # Delete a tool
-  syllable tools delete 5`,
+  syllable tools delete my_tool`,
 	}
 
 	cmd.AddCommand(toolsListCmd())
@@ -173,15 +178,68 @@ func toolsListCmd() *cobra.Command {
 	return cmd
 }
 
+// resolveToolIDFallback maps a failed by-name lookup to a tool name when the
+// argument looks like a numeric ID copied from the `tools list` ID column (#69).
+// The tools get endpoint is name-keyed only, so the ID is resolved via the list
+// endpoint's id search, with an exact client-side match in case the server
+// searches by substring. Returns ok=false when the fallback doesn't apply or
+// finds nothing — callers keep the original by-name error.
+func resolveToolIDFallback(err error, arg string) (string, bool) {
+	var apiErr *client.APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != 404 || !isAllDigits(arg) {
+		return "", false
+	}
+	data, _, lerr := apiClient.Get("/api/v1/tools/?page=0&limit=100&search_fields=id&search_field_values=" + url.QueryEscape(arg))
+	if lerr != nil {
+		return "", false
+	}
+	var result struct {
+		Items []struct {
+			ID   json.Number `json:"id"`
+			Name string      `json:"name"`
+		} `json:"items"`
+	}
+	if json.Unmarshal(data, &result) != nil {
+		return "", false
+	}
+	for _, item := range result.Items {
+		if item.ID.String() == arg {
+			return item.Name, true
+		}
+	}
+	return "", false
+}
+
+// isAllDigits reports whether s is a non-empty ASCII digit string.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 func toolsGetCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "get <tool-name>",
-		Short: "Get a tool by name",
+		Short: "Get a tool by name (numeric IDs are resolved via the list endpoint)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			data, _, err := apiClient.Get("/api/v1/tools/" + args[0])
 			if err != nil {
-				return err
+				// The get endpoint is name-keyed, but `tools list` leads with
+				// the ID column — resolve an all-digits arg by ID and retry (#69).
+				name, ok := resolveToolIDFallback(err, args[0])
+				if !ok {
+					return err
+				}
+				if data, _, err = apiClient.Get("/api/v1/tools/" + name); err != nil {
+					return err
+				}
 			}
 
 			if getOutputFmt() == "json" {


### PR DESCRIPTION
Two get-by-ID ergonomics features, both resolved client-side because the API lacks the endpoints.

## `tools get` accepts numeric IDs (#69)

The get endpoint is name-keyed (`/api/v1/tools/{tool_name}` is all the spec offers), but `tools list` leads with an **ID** column — copying it produced `404: Tool with name 425 not found`. Per the issue's stated preference ("accept either"):

1. Try by name first (zero overhead for the normal path — one request).
2. On a 404 with an all-digits arg, resolve ID → name via the list endpoint's id search (`search_fields=id`, exact client-side match in case the server matches substrings) and retry.
3. Unknown IDs surface the **original** 404 — which now also carries the context-aware hint from #88: *"This command takes a name, not a numeric ID — copy the NAME column from `syllable tools list`."*

Also fixes the misleading help examples (`tools get 5` → `tools get my_tool`, same for update/delete — all three are name-keyed).

## `syllable channels get <channel-id>` (#70)

New command for parity with every other resource. The API has no by-ID GET for channels (the `{channel_id}` path only supports DELETE — see the triage note on the issue), so this resolves via the list endpoint's id search and prints the matching item — exactly the shape of a single item from `channels list -o json`, as the issue requested. Not-found exits 1 pointing at `channels list`. The help text documents the client-side mechanism; if the platform adds a by-ID GET later, spec drift will flag it and the command can switch over.

## Verification

Unit tests (stub server): fallback chain (name-miss → id-resolve → name-get), by-name single-request, unknown-ID keeps original 404, channels exact-match-wins (ids 4 vs 40), channels not-found.

Live against the `cli-test` org:
```
$ syllable --org cli-test tools get 523        → resolves to web_search ✓
$ syllable --org cli-test channels get 76      → Syllable Web Chat ✓
$ syllable --org cli-test channels get 999     → exit 1, "run `syllable channels list`" ✓
```

Closes #69
Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)