### PR TITLE
chore: sync CLI to OpenAPI spec

### DIFF
--- a/scripts/syllable-cli/cmd/conversation_config.go
+++ b/scripts/syllable-cli/cmd/conversation_config.go
@@ -15,9 +15,11 @@ func conversationConfigCmd() *cobra.Command {
 		Long: `Manage conversation configuration.
 
 Bridge phrases — the Console calls these "Voices → Phrases" — are the filler
-messages an agent speaks while it is delayed or a tool call is in progress
-(first_slow_messages, very_slow_messages, tool_responses), with optional
-per-language overrides.`,
+messages an agent speaks while it is delayed or a tool call is in progress.
+Set a unified ordered list via "messages" (with optional "randomize_messages"
+for no-repeat shuffling); when "messages" is empty the legacy fields are used
+(first_slow_messages, very_slow_messages, tool_responses). Per-language
+overrides are also supported.`,
 		Example: `  # Get the current bridge phrases configuration
   syllable conversation-config bridges
 

--- a/scripts/syllable-cli/internal/spec/openapi.json
+++ b/scripts/syllable-cli/internal/spec/openapi.json
@@ -14686,7 +14686,7 @@
             "title": "Batch Id",
             "description": "Unique ID for conversation batch",
             "examples": [
-              "20260603.9"
+              "20260604.9"
             ]
           },
           "campaign_id": {
@@ -14710,7 +14710,7 @@
             "title": "Expires On",
             "description": "Timestamp of batch expiration",
             "examples": [
-              "2026-06-04T00:00:00Z"
+              "2026-06-05T00:00:00Z"
             ]
           },
           "paused": {
@@ -14778,7 +14778,7 @@
             "title": "Created At",
             "description": "Timestamp of batch creation",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "deleted_at": {
@@ -14794,7 +14794,7 @@
             "title": "Deleted At",
             "description": "Timestamp of batch deletion",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "deleted_reason": {
@@ -14825,7 +14825,7 @@
             "title": "Last Updated At",
             "description": "Timestamp of last change to batch",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -15189,6 +15189,20 @@
       },
       "BridgePhraseMessages": {
         "properties": {
+          "messages": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Messages",
+            "description": "Unified ordered bridge phrases. If empty, legacy fields are used."
+          },
+          "randomize_messages": {
+            "type": "boolean",
+            "title": "Randomize Messages",
+            "description": "When true, unified messages are played in randomized no-repeat cycles. Ignored when unified messages are disabled.",
+            "default": false
+          },
           "first_slow_messages": {
             "items": {
               "type": "string"
@@ -15220,6 +15234,20 @@
       },
       "BridgePhrasesConfig": {
         "properties": {
+          "messages": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Messages",
+            "description": "Unified ordered bridge phrases. If empty, legacy fields are used."
+          },
+          "randomize_messages": {
+            "type": "boolean",
+            "title": "Randomize Messages",
+            "description": "When true, unified messages are played in randomized no-repeat cycles. Ignored when unified messages are disabled.",
+            "default": false
+          },
           "first_slow_messages": {
             "items": {
               "type": "string"
@@ -15899,7 +15927,7 @@
             "title": "Batch Id",
             "description": "Unique ID for conversation batch",
             "examples": [
-              "20260603.9"
+              "20260604.9"
             ]
           },
           "campaign_id": {
@@ -15923,7 +15951,7 @@
             "title": "Expires On",
             "description": "Timestamp of batch expiration",
             "examples": [
-              "2026-06-04T00:00:00Z"
+              "2026-06-05T00:00:00Z"
             ]
           },
           "paused": {
@@ -15991,7 +16019,7 @@
             "title": "Created At",
             "description": "Timestamp of batch creation",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "deleted_at": {
@@ -16007,7 +16035,7 @@
             "title": "Deleted At",
             "description": "Timestamp of batch deletion",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "deleted_reason": {
@@ -16038,7 +16066,7 @@
             "title": "Last Updated At",
             "description": "Timestamp of last change to batch",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -16081,7 +16109,7 @@
             "title": "Batch Id",
             "description": "Unique ID for conversation batch",
             "examples": [
-              "20260603.9"
+              "20260604.9"
             ]
           },
           "campaign_id": {
@@ -16105,7 +16133,7 @@
             "title": "Expires On",
             "description": "Timestamp of batch expiration",
             "examples": [
-              "2026-06-04T00:00:00Z"
+              "2026-06-05T00:00:00Z"
             ]
           },
           "paused": {
@@ -16254,7 +16282,7 @@
             "title": "Created At",
             "description": "Timestamp of request creation",
             "examples": [
-              "2026-06-02T00:00:00Z"
+              "2026-06-03T00:00:00Z"
             ]
           },
           "sent_at": {
@@ -16270,7 +16298,7 @@
             "title": "Sent At",
             "description": "Timestamp at which request was sent",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "attempt_count": {
@@ -19652,7 +19680,7 @@
             "title": "Created At",
             "description": "Timestamp at which insight upload folder was created",
             "examples": [
-              "2026-06-02T00:00:00Z"
+              "2026-06-03T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -19661,7 +19689,7 @@
             "title": "Updated At",
             "description": "Timestamp at which insight upload folder was last updated",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -20664,7 +20692,7 @@
             "title": "Created At",
             "description": "Timestamp of at which insight tool configuration was created",
             "examples": [
-              "2026-06-02T00:00:00Z"
+              "2026-06-03T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -20673,7 +20701,7 @@
             "title": "Updated At",
             "description": "Timestamp at which insight tool configuration was last updated",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -21054,7 +21082,7 @@
             "title": "Start Datetime",
             "description": "Target session timestamp the workflow (backfill) should start. An empty value indicates start on activation - live sessions only",
             "examples": [
-              "2026-06-02T00:00:00Z"
+              "2026-06-03T00:00:00Z"
             ]
           },
           "end_datetime": {
@@ -21070,7 +21098,7 @@
             "title": "End Datetime",
             "description": "Target session timestamp the workflow (backfill) should end. An empty value indicates no end, i.e., include live sessions until deactivation",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           }
         },
@@ -21145,7 +21173,7 @@
             "title": "Start Datetime",
             "description": "Target session timestamp the workflow (backfill) should start. An empty value indicates start on activation - live sessions only",
             "examples": [
-              "2026-06-02T00:00:00Z"
+              "2026-06-03T00:00:00Z"
             ]
           },
           "end_datetime": {
@@ -21161,7 +21189,7 @@
             "title": "End Datetime",
             "description": "Target session timestamp the workflow (backfill) should end. An empty value indicates no end, i.e., include live sessions until deactivation",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "id": {
@@ -21229,7 +21257,7 @@
             "title": "Created At",
             "description": "Timestamp at which the insight workflow was created",
             "examples": [
-              "2026-06-02T00:00:00Z"
+              "2026-06-03T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -21238,7 +21266,7 @@
             "title": "Updated At",
             "description": "Timestamp of most recent update to the insight workflow",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -21334,7 +21362,7 @@
             "title": "Created At",
             "description": "Timestamp at which insight upload folder was created",
             "examples": [
-              "2026-06-02T00:00:00Z"
+              "2026-06-03T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -21343,7 +21371,7 @@
             "title": "Updated At",
             "description": "Timestamp at which insight upload folder was last updated",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -21593,7 +21621,7 @@
             "title": "Created At",
             "description": "Timestamp at which insight tool result was created",
             "examples": [
-              "2026-06-02T00:00:00Z"
+              "2026-06-03T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -21602,7 +21630,7 @@
             "title": "Updated At",
             "description": "Timestamp at which insight tool result was last updated",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "upload_file_metadata": {
@@ -21747,7 +21775,7 @@
             "title": "Start Time",
             "description": "Start time of the uploaded file",
             "examples": [
-              "2026-06-02T00:00:00Z"
+              "2026-06-03T00:00:00Z"
             ]
           },
           "end_time": {
@@ -21763,7 +21791,7 @@
             "title": "End Time",
             "description": "End time of the uploaded file",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "error_message": {
@@ -21818,7 +21846,7 @@
             "title": "Created At",
             "description": "Timestamp at which insight upload file was created",
             "examples": [
-              "2026-06-02T00:00:00Z"
+              "2026-06-03T00:00:00Z"
             ]
           }
         },
@@ -25553,7 +25581,7 @@
             "title": "Created At",
             "description": "Timestamp of campaign creation",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -25562,7 +25590,7 @@
             "title": "Updated At",
             "description": "Timestamp of campaign update",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -28413,6 +28441,7 @@
           "source",
           "target",
           "duration",
+          "is_outbound",
           "is_legacy",
           "is_test"
         ],


### PR DESCRIPTION
## Summary

Reconciles the embedded OpenAPI spec (`scripts/syllable-cli/internal/spec/openapi.json`) with upstream `asksyllable/syllable-sdk-typescript@main`. **Purely additive** — no paths, commands, or flags changed.

### Changes
- **`BridgePhraseMessages`** — adds optional `messages` (`string[]`, "Unified ordered bridge phrases; if empty, legacy fields are used") and `randomize_messages` (`bool`, default `false`).
- **`BridgePhrasesConfig`** — adds the same two optional fields.
- **`SessionProperties` enum** — adds the value `is_outbound`.

### Code/docs
No Go command changes are required:
- `conversation-config bridges` / `bridges-update` are pass-through (`--file` JSON body in, JSON out) — the new fields flow through transparently.
- `sessions list --search-field` is free-form, so the new `is_outbound` property value works without code changes.
- Updated the `conversation-config` help text to document the new unified `messages` / `randomize_messages` fields.

> Note (not in this PR, possible future enhancement): `is_outbound` is a curated-but-omitted column on `sessions list`/`get` and could be surfaced like `is_test`. Left out to keep this sync minimal.

## `diff_specs.py` report (embedded → upstream, before sync)

```
## CHANGED SCHEMAS — field-level diffs (2)

~ BridgePhraseMessages
  + messages: array
  + randomize_messages: boolean

~ BridgePhrasesConfig
  + messages: array
  + randomize_messages: boolean

## SUMMARY
  Paths:   +0 added, -0 removed, ~0 changed
  Schemas: +0 added, -0 removed, ~2 changed
```

After replacing the embedded spec, `diff_specs.py --exit-code` returns **0** (in sync).

> The `SessionProperties` enum addition (`is_outbound`) is **not** reported by `diff_specs.py` — the script doesn't diff enum members. It was caught by inspecting the raw JSON diff. Worth a follow-up to teach the diff script about enum-value changes.

## Breaking changes

**None — purely additive.** Only new optional fields and a new enum value; nothing removed, renamed, narrowed, or made required. No removed paths/commands/flags.

## Verification
- `go test ./...` passes (cmd, integration, internal/client, internal/output, internal/spec).
- `diff_specs.py --exit-code` returns 0 after the sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
