### PR TITLE
docs: make merger routine prompt the full verify-merge-publish cycle

### DIFF
--- a/.claude/skills/syllable-sync/routines/merger.md
+++ b/.claude/skills/syllable-sync/routines/merger.md
@@ -1,43 +1,43 @@
-# Routine: spec-sync merger (independent reviewer + merger)
+# Routine: spec-sync merger (independent verifier + merger + publisher)
 
-**Canonical prompt for the merging routine.** Paste this into a *separate* scheduled Claude Code routine from the [reconciler](./reconciler.md), with the `asksyllable/syllable-cli` repo selected. Run it daily (or on demand). Keeping it separate from the reconciler is the point: an independent session that **re-derives the truth from source** instead of trusting the PR's own review prose.
+**Canonical prompt for the merging routine.** Paste the prompt below into a *separate* scheduled Claude Code routine from the [reconciler](./reconciler.md), with the `asksyllable/syllable-cli` repo selected, scheduled to run shortly **after** the reconciler (e.g. reconciler at 6am, merger at 7am — enough gap for the PR's CI to finish). Keeping it separate from the reconciler is the point: an independent session that **re-derives the truth from source** instead of trusting the PR's own review prose.
 
 > Why separate + independent: in the cycle that built this, the reconciler's self-review *and* a Codex pass both confidently described a change, and a reviewer reading that same narrative would have inherited the same blind spot. What actually decides correctness is a fresh, mechanical re-derivation from the specs and the tests — not anyone's review text (including a previous agent's, and including your own first impression).
 
-Your job: for each open reconciliation PR, independently verify it and **merge only if it is green and purely additive**. When in doubt, do not merge — you are the last gate before users.
+This routine runs the **full downstream cycle** — verify → merge → version bump → publish → Homebrew — with no human in the loop for the common case. The one safety valve: it acts automatically **only when the change is purely additive and every gate is green**; anything breaking, ambiguous, or not-green it routes to a human instead. That valve isn't a brake on automation — it's what makes unattended publishing safe.
 
-For each open PR labelled `spec-sync` (`gh pr list --label spec-sync --state open`):
+**Before you set it up — two operating requirements:**
 
-1. **Re-derive the diff yourself — do NOT read the PR's own review comments first.** Fetch the PR head. Run the enum-aware diff between `main` (or the PR's merge base) and the PR's embedded spec:
-   `python3 .claude/skills/syllable-sync/scripts/diff_specs.py --exit-code --format json <base-spec> <pr-spec>`
-   Decide independently what changed: paths, schemas, fields, and **enum members** (the diff now reports enum add/remove; a removed value is breaking).
+1. **Run it where its tag-push triggers the release.** The release step only fires if the `vX.Y.Z` tag is pushed with credentials GitHub lets trigger workflows. A tag pushed by the default GitHub Actions token is deliberately suppressed (loop-prevention), so the build and Homebrew update would **silently never happen**. Run this routine locally with your own git credentials, or give it a personal access token. (The reconciler has no such requirement — it only opens a PR.)
+2. **Watch the first live cycle before trusting it unattended.** This routine merges and publishes to users — the one action you cannot walk back. Observe its first clean end-to-end cycle (or two) before you stop checking. After that it's genuinely hands-off.
+
+---
+
+You are the independent verifier-and-merger for spec-sync reconciliation PRs in `asksyllable/syllable-cli`. You run after the reconciler routine, which opens these PRs. Your job: independently verify each PR, and if it is purely additive and fully green, **merge it, cut the version release, and ship the Homebrew update** — the complete cycle, no human in the loop. If anything is breaking, ambiguous, or not green, **STOP and leave it for a human**. When in doubt, do not merge — you are the last gate before users.
+
+Run `git fetch origin`. For each open PR labelled `spec-sync` (`gh pr list --label spec-sync --state open`). If there are none, stop — there's nothing to do.
+
+1. **Re-derive the diff yourself — do NOT read the PR's own review comments first.** The point of this routine is an independent check; reading the PR's narrative first would bias you toward its conclusions. Get the PR's spec (`gh pr checkout <n>`, then `scripts/syllable-cli/internal/spec/openapi.json`) and the base (`git show origin/main:scripts/syllable-cli/internal/spec/openapi.json`). Run the enum-aware diff between them:
+   `python3 .claude/skills/syllable-sync/scripts/diff_specs.py --exit-code --format json <base> <pr-spec>`
+   Decide for yourself what changed: paths, schemas, fields, and enum members (a removed enum value is breaking).
 
 2. **Classify additive vs breaking from YOUR diff, conservatively.**
-   - **Breaking** = any removed path / command / flag, any **removed enum value**, any newly-required field, a narrowed type, or changed semantics.
+   - **Breaking** = any removed path/command/flag, any removed enum value, any newly-required field, a narrowed type, or changed semantics.
    - **Purely additive** = new paths/commands + new *optional* fields + new enum values, and nothing else.
-   - If breaking or ambiguous → **do not merge.** Comment with exactly what you found and leave it for a human.
+   - If breaking or ambiguous → **do not merge.** Comment exactly what you found, leave it for a human, and move on to the next PR.
 
-3. **Verify the gates are independently green** (`gh pr checks <n>`):
-   - `test` (unit) **and** `spec-live-check` (live `cli-test`) must both be **passing**. If either is missing or red → do not merge.
-   - Confirm `spec-live-check` actually exercised the new commands (Stage 1 coverage), not just pre-existing ones — if a new command has no integration test, treat the QA as incomplete and leave it for a human.
+3. **Verify the gates are independently green** (`gh pr checks <n>`): `test` (unit) **and** `spec-live-check` (live `cli-test` org) must both be present and **passing**. If either is missing, pending, or red → do not merge; comment and leave for a human. Confirm `spec-live-check` actually exercised the **new** commands (Stage 1 coverage), not just pre-existing ones — if a new command has no integration test, treat the QA as incomplete and leave it for a human.
 
-4. **Spot-check the code yourself** (don't rely on the author's notes): new command paths match the spec including trailing slashes, required fields are covered by flags, IDs handled (int vs string), and each new command has a test.
+4. **Spot-check the code yourself** (don't rely on the author's notes): new command paths match the spec including trailing slashes (a collection path ends in `/`, an item path does not — a mismatch drops the `Syllable-API-Key` header on a 307), required fields are covered by flags, IDs handled correctly (int vs string), and each new command has a test.
 
-5. **Merge only if** purely additive **and** all gates green **and** your spot-check is clean:
-   `gh pr merge <n> --squash --delete-branch`. Confirm the linked `spec-drift` issue closed (if it didn't, close it, and note the PR was missing its `Closes #N`).
+5. **Merge — only if purely additive AND all gates green AND your spot-check is clean:**
+   `gh pr merge <n> --squash --delete-branch`
+   Confirm the linked `spec-drift` issue closed (if it didn't, close it, and note the PR was missing its `Closes #N`).
 
-6. **Release** (only once you're cleared to publish — see "Rollout" below):
-   - Compute the bump from *your* diff: new paths/commands → **minor**; additive fields / enum values → **patch**; anything breaking → never (it went to a human).
-   - Tag `vX.Y.Z` and push it **with your own credentials** (a tag pushed by a bot/`GITHUB_TOKEN` will NOT trigger `release.yml`). GoReleaser builds, publishes the release, and opens the Homebrew cask PR.
-   - **Set the GitHub release notes from the PR's `Release notes` section** (and your diff). GoReleaser's commit-based changelog omits `chore:`/field-only changes, so write the notes explicitly: list the additive changes in plain language. Do not ship an empty `## Changelog`.
+6. **Release and publish:**
+   - Compute the bump from *your* diff: new paths/commands → **minor**; additive fields / enum values only → **patch**.
+   - Tag `vX.Y.Z` and push it **with credentials that trigger `release.yml`** — a tag pushed by the default GitHub Actions token will NOT trigger the release workflow. GoReleaser then builds, publishes the GitHub release, and opens the Homebrew cask PR.
+   - **Set the GitHub release notes from the PR's `Release notes` section** (and your diff). GoReleaser's commit-based changelog omits `chore:`/field-only changes, so write the notes explicitly — never ship an empty `## Changelog`.
    - Merge the `chore: update Homebrew cask …` PR so `brew` users get it.
 
-7. **If anything is off** — a red or missing gate, a breaking change, your diff disagrees with the PR, or a new command lacks a test — **comment with specifics and leave the PR for a human. Never merge on doubt.**
-
-## Rollout (do not skip)
-
-- **Phase A — review only:** do steps 1–4 and post your independent verdict as a comment. Do **not** merge. Let a human merge while you build confidence that your verdicts match reality.
-- **Phase B — auto-merge:** enable step 5 (merge purely-additive, green PRs).
-- **Phase C — auto-publish:** enable step 6.
-
-Advance one phase at a time, only after several clean observed cycles. Auto-publishing to users is the one action you cannot walk back.
+7. **If anything is off** — a breaking or ambiguous change, a red/missing/pending gate, your diff disagrees with the PR, or a new command lacks a test — **comment with specifics and leave the PR for a human. Never merge or release on doubt.**

--- a/.claude/skills/syllable-sync/routines/merger.md
+++ b/.claude/skills/syllable-sync/routines/merger.md
@@ -26,7 +26,11 @@ Run `git fetch origin`. For each open PR labelled `spec-sync` (`gh pr list --lab
    - **Purely additive** = new paths/commands + new *optional* fields + new enum values, and nothing else.
    - If breaking or ambiguous → **do not merge.** Comment exactly what you found, leave it for a human, and move on to the next PR.
 
-3. **Verify the gates are independently green** (`gh pr checks <n>`): `test` (unit) **and** `spec-live-check` (live `cli-test` org) must both be present and **passing**. If either is missing, pending, or red → do not merge; comment and leave for a human. Confirm `spec-live-check` actually exercised the **new** commands (Stage 1 coverage), not just pre-existing ones — if a new command has no integration test, treat the QA as incomplete and leave it for a human.
+3. **Verify the gates mechanically — read the actual check results, never infer.** This is the only enforcement standing between an automated change and users for the integration tests (GoReleaser's pre-release hook re-runs the *unit* tests before publishing, but not the live ones), so be strict. Run `gh pr checks <n> --json name,state,bucket` (or `gh pr view <n> --json statusCheckRollup`) and inspect **every** entry:
+   - The unit-test check (`test`) must be **SUCCESS**.
+   - The live integration check (`live-check` — the job from `spec-live-check.yml` against the `cli-test` org) must be **SUCCESS**, meaning it actually ran. A **SKIPPED** `live-check` means the `spec-sync` label wasn't applied so the live QA never ran — do **not** merge; apply the label, let it run, then re-check.
+   - Every other check must be SUCCESS or SKIPPED. If **any** check is pending, queued, in progress, failed, cancelled, or absent → do not merge; comment and leave for a human. Only an explicit pass/skip in the JSON counts — never assume "it's probably fine."
+   Also confirm `live-check` actually exercised the **new** commands (Stage 1 coverage), not just pre-existing ones — if a new command has no integration test, treat the QA as incomplete and leave it for a human.
 
 4. **Spot-check the code yourself** (don't rely on the author's notes): new command paths match the spec including trailing slashes (a collection path ends in `/`, an item path does not — a mismatch drops the `Syllable-API-Key` header on a 307), required fields are covered by flags, IDs handled correctly (int vs string), and each new command has a test.
 

--- a/.claude/skills/syllable-sync/routines/merger.md
+++ b/.claude/skills/syllable-sync/routines/merger.md
@@ -15,7 +15,7 @@ This routine runs the **full downstream cycle** — verify → merge → version
 
 You are the independent verifier-and-merger for spec-sync reconciliation PRs in `asksyllable/syllable-cli`. You run after the reconciler routine, which opens these PRs. Your job: independently verify each PR, and if it is purely additive and fully green, **merge it, cut the version release, and ship the Homebrew update** — the complete cycle, no human in the loop. If anything is breaking, ambiguous, or not green, **STOP and leave it for a human**. When in doubt, do not merge — you are the last gate before users.
 
-Run `git fetch origin`. For each open PR labelled `spec-sync` (`gh pr list --label spec-sync --state open`). If there are none, stop — there's nothing to do.
+Run `git fetch origin`. For each open PR labelled `spec-sync` (`gh pr list --label spec-sync --state open`). **Skip any PR that is a draft** (check `gh pr view <n> --json isDraft`) — the reconciler opens breaking or ambiguous syncs as drafts to signal "a human needs to decide this," so a draft is never yours to merge. If there are no non-draft `spec-sync` PRs, stop — there's nothing to do.
 
 1. **Re-derive the diff yourself — do NOT read the PR's own review comments first.** The point of this routine is an independent check; reading the PR's narrative first would bias you toward its conclusions. Get the PR's spec (`gh pr checkout <n>`, then `scripts/syllable-cli/internal/spec/openapi.json`) and the base (`git show origin/main:scripts/syllable-cli/internal/spec/openapi.json`). Run the enum-aware diff between them:
    `python3 .claude/skills/syllable-sync/scripts/diff_specs.py --exit-code --format json <base> <pr-spec>`


### PR DESCRIPTION
## What

Makes `.claude/skills/syllable-sync/routines/merger.md` the canonical **full-cycle** merger prompt: verify → merge → version bump → publish → Homebrew, with no human in the loop for the common case.

## Why

The merger is being set up as Routine 2, running after the reconciler (Routine 1). The previous file described a phased rollout (review-only → auto-merge → auto-publish); we've decided to go straight to the full cycle, with safety coming from the conservative gate rather than a staged ramp.

## Safety model

It acts automatically **only when the change is purely additive and every gate (`test` + `spec-live-check`) is green**. Anything breaking, ambiguous, or not-green is left for a human. Two operating requirements are now called out at the top:

1. Run it where its tag-push triggers `release.yml` — local git credentials or a PAT, not the default Actions token (which GitHub suppresses to prevent loops, so the build + Homebrew update would silently never fire).
2. Watch the first live cycle before trusting it unattended.

Docs/skill-only change — no CLI code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)