### PR TITLE
chore: sync CLI to OpenAPI spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -546,7 +546,7 @@ syllable permissions list
 ```
 
 ### Conversation Config
-Bridge phrases — the filler messages an agent speaks while it is delayed or a tool call is in progress. This is the feature the Console shows under **Voices → Phrases**. Config fields: `first_slow_messages`, `very_slow_messages`, `tool_responses`, plus per-language overrides under `localized`.
+Bridge phrases — the filler messages an agent speaks while it is delayed or a tool call is in progress. This is the feature the Console shows under **Voices → Phrases**. Config fields: `first_slow_messages`, `very_slow_messages`, `tool_responses`, `smart_turn_timeout_seconds` (seconds of caller silence before the first bridge phrase; subsequent intervals are 2x/3x/4x this base), plus per-language overrides under `localized`.
 ```bash
 syllable conversation-config bridges
 syllable conversation-config bridges-update --file bridges.json

--- a/scripts/syllable-cli/internal/spec/openapi.json
+++ b/scripts/syllable-cli/internal/spec/openapi.json
@@ -14686,7 +14686,7 @@
             "title": "Batch Id",
             "description": "Unique ID for conversation batch",
             "examples": [
-              "20260604.9"
+              "20260605.9"
             ]
           },
           "campaign_id": {
@@ -14710,7 +14710,7 @@
             "title": "Expires On",
             "description": "Timestamp of batch expiration",
             "examples": [
-              "2026-06-05T00:00:00Z"
+              "2026-06-06T00:00:00Z"
             ]
           },
           "paused": {
@@ -14778,7 +14778,7 @@
             "title": "Created At",
             "description": "Timestamp of batch creation",
             "examples": [
-              "2026-06-04T00:00:00Z"
+              "2026-06-05T00:00:00Z"
             ]
           },
           "deleted_at": {
@@ -14794,7 +14794,7 @@
             "title": "Deleted At",
             "description": "Timestamp of batch deletion",
             "examples": [
-              "2026-06-04T00:00:00Z"
+              "2026-06-05T00:00:00Z"
             ]
           },
           "deleted_reason": {
@@ -14825,7 +14825,7 @@
             "title": "Last Updated At",
             "description": "Timestamp of last change to batch",
             "examples": [
-              "2026-06-04T00:00:00Z"
+              "2026-06-05T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -15279,6 +15279,20 @@
             "type": "object",
             "title": "Localized",
             "description": "Per-language overrides keyed by BCP-47 tag (e.g. \"es-US\")."
+          },
+          "smart_turn_timeout_seconds": {
+            "anyOf": [
+              {
+                "type": "number",
+                "maximum": 30.0,
+                "minimum": 0.25
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Smart Turn Timeout Seconds",
+            "description": "Seconds of caller silence before injecting the first bridge phrase. Subsequent sleep intervals are 2x, 3x, 4x this base. When unset, the service-wide default applies."
           }
         },
         "type": "object",
@@ -15927,7 +15941,7 @@
             "title": "Batch Id",
             "description": "Unique ID for conversation batch",
             "examples": [
-              "20260604.9"
+              "20260605.9"
             ]
           },
           "campaign_id": {
@@ -15951,7 +15965,7 @@
             "title": "Expires On",
             "description": "Timestamp of batch expiration",
             "examples": [
-              "2026-06-05T00:00:00Z"
+              "2026-06-06T00:00:00Z"
             ]
           },
           "paused": {
@@ -16019,7 +16033,7 @@
             "title": "Created At",
             "description": "Timestamp of batch creation",
             "examples": [
-              "2026-06-04T00:00:00Z"
+              "2026-06-05T00:00:00Z"
             ]
           },
           "deleted_at": {
@@ -16035,7 +16049,7 @@
             "title": "Deleted At",
             "description": "Timestamp of batch deletion",
             "examples": [
-              "2026-06-04T00:00:00Z"
+              "2026-06-05T00:00:00Z"
             ]
           },
           "deleted_reason": {
@@ -16066,7 +16080,7 @@
             "title": "Last Updated At",
             "description": "Timestamp of last change to batch",
             "examples": [
-              "2026-06-04T00:00:00Z"
+              "2026-06-05T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -16109,7 +16123,7 @@
             "title": "Batch Id",
             "description": "Unique ID for conversation batch",
             "examples": [
-              "20260604.9"
+              "20260605.9"
             ]
           },
           "campaign_id": {
@@ -16133,7 +16147,7 @@
             "title": "Expires On",
             "description": "Timestamp of batch expiration",
             "examples": [
-              "2026-06-05T00:00:00Z"
+              "2026-06-06T00:00:00Z"
             ]
           },
           "paused": {
@@ -16282,7 +16296,7 @@
             "title": "Created At",
             "description": "Timestamp of request creation",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "sent_at": {
@@ -16298,7 +16312,7 @@
             "title": "Sent At",
             "description": "Timestamp at which request was sent",
             "examples": [
-              "2026-06-04T00:00:00Z"
+              "2026-06-05T00:00:00Z"
             ]
           },
           "attempt_count": {
@@ -19680,7 +19694,7 @@
             "title": "Created At",
             "description": "Timestamp at which insight upload folder was created",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -19689,7 +19703,7 @@
             "title": "Updated At",
             "description": "Timestamp at which insight upload folder was last updated",
             "examples": [
-              "2026-06-04T00:00:00Z"
+              "2026-06-05T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -20692,7 +20706,7 @@
             "title": "Created At",
             "description": "Timestamp of at which insight tool configuration was created",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -20701,7 +20715,7 @@
             "title": "Updated At",
             "description": "Timestamp at which insight tool configuration was last updated",
             "examples": [
-              "2026-06-04T00:00:00Z"
+              "2026-06-05T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -21082,7 +21096,7 @@
             "title": "Start Datetime",
             "description": "Target session timestamp the workflow (backfill) should start. An empty value indicates start on activation - live sessions only",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "end_datetime": {
@@ -21098,7 +21112,7 @@
             "title": "End Datetime",
             "description": "Target session timestamp the workflow (backfill) should end. An empty value indicates no end, i.e., include live sessions until deactivation",
             "examples": [
-              "2026-06-04T00:00:00Z"
+              "2026-06-05T00:00:00Z"
             ]
           }
         },
@@ -21173,7 +21187,7 @@
             "title": "Start Datetime",
             "description": "Target session timestamp the workflow (backfill) should start. An empty value indicates start on activation - live sessions only",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "end_datetime": {
@@ -21189,7 +21203,7 @@
             "title": "End Datetime",
             "description": "Target session timestamp the workflow (backfill) should end. An empty value indicates no end, i.e., include live sessions until deactivation",
             "examples": [
-              "2026-06-04T00:00:00Z"
+              "2026-06-05T00:00:00Z"
             ]
           },
           "id": {
@@ -21257,7 +21271,7 @@
             "title": "Created At",
             "description": "Timestamp at which the insight workflow was created",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -21266,7 +21280,7 @@
             "title": "Updated At",
             "description": "Timestamp of most recent update to the insight workflow",
             "examples": [
-              "2026-06-04T00:00:00Z"
+              "2026-06-05T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -21362,7 +21376,7 @@
             "title": "Created At",
             "description": "Timestamp at which insight upload folder was created",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -21371,7 +21385,7 @@
             "title": "Updated At",
             "description": "Timestamp at which insight upload folder was last updated",
             "examples": [
-              "2026-06-04T00:00:00Z"
+              "2026-06-05T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -21621,7 +21635,7 @@
             "title": "Created At",
             "description": "Timestamp at which insight tool result was created",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -21630,7 +21644,7 @@
             "title": "Updated At",
             "description": "Timestamp at which insight tool result was last updated",
             "examples": [
-              "2026-06-04T00:00:00Z"
+              "2026-06-05T00:00:00Z"
             ]
           },
           "upload_file_metadata": {
@@ -21775,7 +21789,7 @@
             "title": "Start Time",
             "description": "Start time of the uploaded file",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           },
           "end_time": {
@@ -21791,7 +21805,7 @@
             "title": "End Time",
             "description": "End time of the uploaded file",
             "examples": [
-              "2026-06-04T00:00:00Z"
+              "2026-06-05T00:00:00Z"
             ]
           },
           "error_message": {
@@ -21846,7 +21860,7 @@
             "title": "Created At",
             "description": "Timestamp at which insight upload file was created",
             "examples": [
-              "2026-06-03T00:00:00Z"
+              "2026-06-04T00:00:00Z"
             ]
           }
         },
@@ -25581,7 +25595,7 @@
             "title": "Created At",
             "description": "Timestamp of campaign creation",
             "examples": [
-              "2026-06-04T00:00:00Z"
+              "2026-06-05T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -25590,7 +25604,7 @@
             "title": "Updated At",
             "description": "Timestamp of campaign update",
             "examples": [
-              "2026-06-04T00:00:00Z"
+              "2026-06-05T00:00:00Z"
             ]
           },
           "last_updated_by": {


### PR DESCRIPTION
## Spec sync — `BridgePhrasesConfig.smart_turn_timeout_seconds`

Automated reconciliation of the embedded OpenAPI spec against upstream
([asksyllable/syllable-sdk-typescript@main](https://raw.githubusercontent.com/asksyllable/syllable-sdk-typescript/main/openapi.json)).

### `diff_specs.py` report

```
## CHANGED SCHEMAS — field-level diffs (1)

~ BridgePhrasesConfig
  + smart_turn_timeout_seconds: anyOf

## SUMMARY
  Paths:   +0 added, -0 removed, ~0 changed
  Schemas: +0 added, -0 removed, ~1 changed
  Enums:   ~0 changed (0 with removed values — breaking)
```

The new field:

```jsonc
"smart_turn_timeout_seconds": {
  "anyOf": [ { "type": "number", "maximum": 30.0, "minimum": 0.25 }, { "type": "null" } ],
  "title": "Smart Turn Timeout Seconds",
  "description": "Seconds of caller silence before injecting the first bridge phrase. Subsequent sleep intervals are 2x, 3x, 4x this base. When unset, the service-wide default applies."
}
```

### Code impact

None required. `BridgePhrasesConfig` is consumed only by `conversation-config bridges-update`, which accepts an arbitrary JSON body via `--file` (no per-field flags), so the new optional field passes through transparently. The field is not surfaced anywhere else in `cmd/*.go`.

The remaining lines in the spec diff are auto-rolling example timestamps (`20260604.9` → `20260605.9`, etc.) that change daily upstream — cosmetic, no structural effect.

### Changes

- `scripts/syllable-cli/internal/spec/openapi.json` — verbatim upstream copy
- `AGENTS.md` — note the new field in the Conversation Config section

### Breaking changes

**None.** Purely additive: one new *optional* nullable field on an existing schema. No removed paths/commands/flags, no changed/removed enum values, no newly-required fields, no narrowed types.

### Release notes

`conversation-config bridges-update` now accepts a `smart_turn_timeout_seconds`
field in the bridge-phrases JSON body — tunes how long an agent waits on caller
silence before the first bridge phrase (0.25–30s; subsequent intervals scale
2x/3x/4x). Optional; the service-wide default applies when unset.

### Tests

`go test ./...` passes (cmd, integration, internal/spec, client, output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
