### PR TITLE
chore: sync CLI to OpenAPI spec

### DIFF
--- a/scripts/syllable-cli/internal/spec/openapi.json
+++ b/scripts/syllable-cli/internal/spec/openapi.json
@@ -14687,7 +14687,7 @@
             "title": "Batch Id",
             "description": "Unique ID for conversation batch",
             "examples": [
-              "20260606.9"
+              "20260610.9"
             ]
           },
           "campaign_id": {
@@ -14711,7 +14711,7 @@
             "title": "Expires On",
             "description": "Timestamp of batch expiration",
             "examples": [
-              "2026-06-07T00:00:00Z"
+              "2026-06-11T00:00:00Z"
             ]
           },
           "paused": {
@@ -14779,7 +14779,7 @@
             "title": "Created At",
             "description": "Timestamp of batch creation",
             "examples": [
-              "2026-06-06T00:00:00Z"
+              "2026-06-10T00:00:00Z"
             ]
           },
           "deleted_at": {
@@ -14795,7 +14795,7 @@
             "title": "Deleted At",
             "description": "Timestamp of batch deletion",
             "examples": [
-              "2026-06-06T00:00:00Z"
+              "2026-06-10T00:00:00Z"
             ]
           },
           "deleted_reason": {
@@ -14826,7 +14826,7 @@
             "title": "Last Updated At",
             "description": "Timestamp of last change to batch",
             "examples": [
-              "2026-06-06T00:00:00Z"
+              "2026-06-10T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -15586,6 +15586,7 @@
           "DUPLICATE",
           "INVALID",
           "FAILED",
+          "FILTERED_LINE_TYPE",
           "PROCESSED",
           "DROPPED",
           "DEFERRED",
@@ -15960,7 +15961,7 @@
             "title": "Batch Id",
             "description": "Unique ID for conversation batch",
             "examples": [
-              "20260606.9"
+              "20260610.9"
             ]
           },
           "campaign_id": {
@@ -15984,7 +15985,7 @@
             "title": "Expires On",
             "description": "Timestamp of batch expiration",
             "examples": [
-              "2026-06-07T00:00:00Z"
+              "2026-06-11T00:00:00Z"
             ]
           },
           "paused": {
@@ -16052,7 +16053,7 @@
             "title": "Created At",
             "description": "Timestamp of batch creation",
             "examples": [
-              "2026-06-06T00:00:00Z"
+              "2026-06-10T00:00:00Z"
             ]
           },
           "deleted_at": {
@@ -16068,7 +16069,7 @@
             "title": "Deleted At",
             "description": "Timestamp of batch deletion",
             "examples": [
-              "2026-06-06T00:00:00Z"
+              "2026-06-10T00:00:00Z"
             ]
           },
           "deleted_reason": {
@@ -16099,7 +16100,7 @@
             "title": "Last Updated At",
             "description": "Timestamp of last change to batch",
             "examples": [
-              "2026-06-06T00:00:00Z"
+              "2026-06-10T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -16142,7 +16143,7 @@
             "title": "Batch Id",
             "description": "Unique ID for conversation batch",
             "examples": [
-              "20260606.9"
+              "20260610.9"
             ]
           },
           "campaign_id": {
@@ -16166,7 +16167,7 @@
             "title": "Expires On",
             "description": "Timestamp of batch expiration",
             "examples": [
-              "2026-06-07T00:00:00Z"
+              "2026-06-11T00:00:00Z"
             ]
           },
           "paused": {
@@ -16315,7 +16316,7 @@
             "title": "Created At",
             "description": "Timestamp of request creation",
             "examples": [
-              "2026-06-05T00:00:00Z"
+              "2026-06-09T00:00:00Z"
             ]
           },
           "sent_at": {
@@ -16331,7 +16332,7 @@
             "title": "Sent At",
             "description": "Timestamp at which request was sent",
             "examples": [
-              "2026-06-06T00:00:00Z"
+              "2026-06-10T00:00:00Z"
             ]
           },
           "attempt_count": {
@@ -16385,7 +16386,8 @@
               "COMPLETED",
               "FAILED",
               "CANCELED",
-              "INVALID"
+              "INVALID",
+              "SKIPPED"
             ]
           },
           "channel_manager_status": {
@@ -16453,6 +16455,23 @@
                 "rating": "Good",
                 "summary": "The customer service agent successfully assisted the caller with their inquiry and the call ended positively."
               }
+            ]
+          },
+          "line_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Line Type",
+            "description": "Line type of the target number from Twilio Lookup (e.g. 'mobile', 'landline', 'voip'); resolved at ingestion.",
+            "examples": [
+              "mobile",
+              "landline",
+              "voip"
             ]
           }
         },
@@ -19713,7 +19732,7 @@
             "title": "Created At",
             "description": "Timestamp at which insight upload folder was created",
             "examples": [
-              "2026-06-05T00:00:00Z"
+              "2026-06-09T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -19722,7 +19741,7 @@
             "title": "Updated At",
             "description": "Timestamp at which insight upload folder was last updated",
             "examples": [
-              "2026-06-06T00:00:00Z"
+              "2026-06-10T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -20725,7 +20744,7 @@
             "title": "Created At",
             "description": "Timestamp of at which insight tool configuration was created",
             "examples": [
-              "2026-06-05T00:00:00Z"
+              "2026-06-09T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -20734,7 +20753,7 @@
             "title": "Updated At",
             "description": "Timestamp at which insight tool configuration was last updated",
             "examples": [
-              "2026-06-06T00:00:00Z"
+              "2026-06-10T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -21115,7 +21134,7 @@
             "title": "Start Datetime",
             "description": "Target session timestamp the workflow (backfill) should start. An empty value indicates start on activation - live sessions only",
             "examples": [
-              "2026-06-05T00:00:00Z"
+              "2026-06-09T00:00:00Z"
             ]
           },
           "end_datetime": {
@@ -21131,7 +21150,7 @@
             "title": "End Datetime",
             "description": "Target session timestamp the workflow (backfill) should end. An empty value indicates no end, i.e., include live sessions until deactivation",
             "examples": [
-              "2026-06-06T00:00:00Z"
+              "2026-06-10T00:00:00Z"
             ]
           }
         },
@@ -21206,7 +21225,7 @@
             "title": "Start Datetime",
             "description": "Target session timestamp the workflow (backfill) should start. An empty value indicates start on activation - live sessions only",
             "examples": [
-              "2026-06-05T00:00:00Z"
+              "2026-06-09T00:00:00Z"
             ]
           },
           "end_datetime": {
@@ -21222,7 +21241,7 @@
             "title": "End Datetime",
             "description": "Target session timestamp the workflow (backfill) should end. An empty value indicates no end, i.e., include live sessions until deactivation",
             "examples": [
-              "2026-06-06T00:00:00Z"
+              "2026-06-10T00:00:00Z"
             ]
           },
           "id": {
@@ -21290,7 +21309,7 @@
             "title": "Created At",
             "description": "Timestamp at which the insight workflow was created",
             "examples": [
-              "2026-06-05T00:00:00Z"
+              "2026-06-09T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -21299,7 +21318,7 @@
             "title": "Updated At",
             "description": "Timestamp of most recent update to the insight workflow",
             "examples": [
-              "2026-06-06T00:00:00Z"
+              "2026-06-10T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -21395,7 +21414,7 @@
             "title": "Created At",
             "description": "Timestamp at which insight upload folder was created",
             "examples": [
-              "2026-06-05T00:00:00Z"
+              "2026-06-09T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -21404,7 +21423,7 @@
             "title": "Updated At",
             "description": "Timestamp at which insight upload folder was last updated",
             "examples": [
-              "2026-06-06T00:00:00Z"
+              "2026-06-10T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -21654,7 +21673,7 @@
             "title": "Created At",
             "description": "Timestamp at which insight tool result was created",
             "examples": [
-              "2026-06-05T00:00:00Z"
+              "2026-06-09T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -21663,7 +21682,7 @@
             "title": "Updated At",
             "description": "Timestamp at which insight tool result was last updated",
             "examples": [
-              "2026-06-06T00:00:00Z"
+              "2026-06-10T00:00:00Z"
             ]
           },
           "upload_file_metadata": {
@@ -21808,7 +21827,7 @@
             "title": "Start Time",
             "description": "Start time of the uploaded file",
             "examples": [
-              "2026-06-05T00:00:00Z"
+              "2026-06-09T00:00:00Z"
             ]
           },
           "end_time": {
@@ -21824,7 +21843,7 @@
             "title": "End Time",
             "description": "End time of the uploaded file",
             "examples": [
-              "2026-06-06T00:00:00Z"
+              "2026-06-10T00:00:00Z"
             ]
           },
           "error_message": {
@@ -21879,7 +21898,7 @@
             "title": "Created At",
             "description": "Timestamp at which insight upload file was created",
             "examples": [
-              "2026-06-05T00:00:00Z"
+              "2026-06-09T00:00:00Z"
             ]
           }
         },
@@ -22630,6 +22649,16 @@
           "nanoseconds"
         ],
         "title": "LatencyUnitType"
+      },
+      "LineTypeBucket": {
+        "type": "string",
+        "enum": [
+          "mobile",
+          "landline",
+          "voip"
+        ],
+        "title": "LineTypeBucket",
+        "description": "Friendly line-type buckets a campaign can be restricted to dial.\n\nThese map to raw Twilio Lookup v2 line types via\n``lib.twilio.line_type_lookup.LINE_TYPE_BUCKETS``."
       },
       "ListResponse_AgentResponse_": {
         "properties": {
@@ -25585,6 +25614,36 @@
               }
             ]
           },
+          "allowed_line_types": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/LineTypeBucket"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Line Types",
+            "description": "Line-type buckets this campaign is allowed to dial. Empty or omitted means no filter (all line types are dialed).",
+            "examples": [
+              [
+                "mobile",
+                "voip"
+              ]
+            ]
+          },
+          "include_unknown_line_types": {
+            "type": "boolean",
+            "title": "Include Unknown Line Types",
+            "description": "When a line-type filter is active, whether to also dial numbers whose line type is unknown or could not be classified. Has no effect when allowed_line_types is empty.",
+            "default": true,
+            "examples": [
+              true
+            ]
+          },
           "id": {
             "type": "integer",
             "title": "Id",
@@ -25614,7 +25673,7 @@
             "title": "Created At",
             "description": "Timestamp of campaign creation",
             "examples": [
-              "2026-06-06T00:00:00Z"
+              "2026-06-10T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -25623,7 +25682,7 @@
             "title": "Updated At",
             "description": "Timestamp of campaign update",
             "examples": [
-              "2026-06-06T00:00:00Z"
+              "2026-06-10T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -25929,6 +25988,36 @@
                 "voicemail_detection_post_speech_timeout": 1.75,
                 "voicemail_detection_pre_speech_timeout": 3.5
               }
+            ]
+          },
+          "allowed_line_types": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/LineTypeBucket"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Line Types",
+            "description": "Line-type buckets this campaign is allowed to dial. Empty or omitted means no filter (all line types are dialed).",
+            "examples": [
+              [
+                "mobile",
+                "voip"
+              ]
+            ]
+          },
+          "include_unknown_line_types": {
+            "type": "boolean",
+            "title": "Include Unknown Line Types",
+            "description": "When a line-type filter is active, whether to also dial numbers whose line type is unknown or could not be classified. Has no effect when allowed_line_types is empty.",
+            "default": true,
+            "examples": [
+              true
             ]
           },
           "webhooks": {
@@ -27106,7 +27195,8 @@
           "COMPLETED",
           "FAILED",
           "CANCELED",
-          "INVALID"
+          "INVALID",
+          "SKIPPED"
         ],
         "title": "RequestStatus",
         "description": "Status of a communication request."


### PR DESCRIPTION
## Spec sync — line-type campaign filtering

Reconciles the embedded OpenAPI spec (`scripts/syllable-cli/internal/spec/openapi.json`) with upstream `asksyllable/syllable-sdk-typescript@main`. **Purely additive** — no Go changes required.

### Structural diff (`diff_specs.py`)

```
## NEW SCHEMAS (1)
+ LineTypeBucket

## CHANGED SCHEMAS — field-level diffs (3)
~ CommunicationRequestResult
  + line_type: anyOf
~ OutboundCampaign
  + allowed_line_types: anyOf
  + include_unknown_line_types: boolean
~ OutboundCampaignInput
  + allowed_line_types: anyOf
  + include_unknown_line_types: boolean

## CHANGED ENUMS — member diffs (3)
~ ChannelManagerStatus
  + FILTERED_LINE_TYPE
~ LineTypeBucket
  + landline
  + mobile
  + voip
~ RequestStatus
  + SKIPPED

## SUMMARY
  Paths:   +0 added, -0 removed, ~0 changed
  Schemas: +1 added, -0 removed, ~3 changed
  Enums:   ~3 changed (0 with removed values — breaking)
```

### Breaking changes

**None.** No removed commands/flags, no removed enum values, no newly-required fields, no narrowed types. All changes are new optional fields, a new schema, and new enum members.

### Why no Go changes

- The new campaign fields (`allowed_line_types`, `include_unknown_line_types`) are accepted automatically — `outbound campaigns create`/`update` pass the JSON body straight through via `--file`.
- The new schema and enum members surface dynamically through `schema get`/`schema list` from the embedded spec (verified: `schema get LineTypeBucket` returns the new enum).
- No `cmd/*.go` file hardcodes any of these names (grep-confirmed). This mirrors the previous field/enum-only sync (#106), which was likewise spec-only.

### Release notes

Campaigns can now be restricted by phone line type. The spec adds a `LineTypeBucket` vocabulary (`mobile`, `landline`, `voip`) plus `allowed_line_types` and `include_unknown_line_types` fields on outbound campaigns, a `line_type` field on request results, and new status values (`FILTERED_LINE_TYPE`, `SKIPPED`) for calls skipped due to line-type filtering. Set these via `syllable outbound campaigns create --file …`; inspect the vocabulary with `syllable schema get LineTypeBucket`.

Closes #111