### PR TITLE
Code review batch 1: API-contract fixes, delete confirmation, structured config errors

### DIFF
--- a/scripts/syllable-cli/cmd/agents.go
+++ b/scripts/syllable-cli/cmd/agents.go
@@ -339,6 +339,9 @@ func agentsDeleteCmd() *cobra.Command {
 		Short: "Delete an agent",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := confirmDelete(cmd, args); err != nil {
+				return err
+			}
 			data, _, err := apiClient.Delete("/api/v1/agents/" + args[0])
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/agents.go
+++ b/scripts/syllable-cli/cmd/agents.go
@@ -259,10 +259,14 @@ func agentsCreateCmd() *cobra.Command {
 				if name == "" || agentType == "" || promptID == "" || timezone == "" {
 					return fmt.Errorf("required flags: --name, --type, --prompt-id, --timezone (or use --file)")
 				}
+				promptIDInt, err := parseIDFlag("prompt-id", promptID)
+				if err != nil {
+					return err
+				}
 				body = map[string]interface{}{
 					"name":         name,
 					"type":         agentType,
-					"prompt_id":    promptID,
+					"prompt_id":    promptIDInt,
 					"timezone":     timezone,
 					"variables":    map[string]interface{}{},
 					"tool_headers": map[string]interface{}{},

--- a/scripts/syllable-cli/cmd/channels.go
+++ b/scripts/syllable-cli/cmd/channels.go
@@ -52,7 +52,6 @@ func channelsCmd() *cobra.Command {
 	cmd.AddCommand(channelsGetCmd())
 	cmd.AddCommand(channelsCreateCmd())
 	cmd.AddCommand(channelsUpdateCmd())
-	cmd.AddCommand(channelsDeleteCmd())
 	cmd.AddCommand(channelsTargetsCmd())
 	cmd.AddCommand(channelsAvailableTargetsCmd())
 	cmd.AddCommand(channelsTwilioCmd())
@@ -276,22 +275,6 @@ func channelsUpdateCmd() *cobra.Command {
 	return cmd
 }
 
-func channelsDeleteCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "delete <channel-id>",
-		Short: "Delete a channel target (the API has no delete-channel operation)",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			// The only DELETE under /api/v1/channels/{channel_id} is "Delete
-			// Channel Target", which requires a target_id — there is no
-			// operation that deletes a whole channel (#114). Fail fast instead
-			// of sending a request that always 422s.
-			return fmt.Errorf("deleting a channel is not supported by the Syllable API; " +
-				"to remove a target from a channel use: syllable channels targets delete <channel-id> <target-id>")
-		},
-	}
-}
-
 func channelsTargetsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "targets",
@@ -467,6 +450,9 @@ func channelsTargetsDeleteCmd() *cobra.Command {
 		Short: "Delete a channel target",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := confirmDelete(cmd, args); err != nil {
+				return err
+			}
 			// Delete-target is DELETE /channels/{channel_id}?target_id=<id>; the
 			// /targets/{target_id} path only supports GET/PUT (#114). The query
 			// string also suppresses the client's auto-reason param, which this

--- a/scripts/syllable-cli/cmd/channels.go
+++ b/scripts/syllable-cli/cmd/channels.go
@@ -256,7 +256,13 @@ func channelsUpdateCmd() *cobra.Command {
 				return fmt.Errorf("use --file to provide update body")
 			}
 
-			data, _, err := apiClient.Put("/api/v1/channels/"+args[0], body)
+			// PUT exists only on the collection; the API routes by the id inside
+			// the body, so reconcile the positional with it (#68, #114).
+			if err := ensureBodyIdentifier(body, "id", args[0], true); err != nil {
+				return err
+			}
+
+			data, _, err := apiClient.Put("/api/v1/channels/", body)
 			if err != nil {
 				return err
 			}
@@ -273,19 +279,15 @@ func channelsUpdateCmd() *cobra.Command {
 func channelsDeleteCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "delete <channel-id>",
-		Short: "Delete a channel",
+		Short: "Delete a channel target (the API has no delete-channel operation)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Delete("/api/v1/channels/" + args[0])
-			if err != nil {
-				return err
-			}
-			if len(data) > 0 {
-				output.PrintJSON(data)
-			} else {
-				fmt.Printf("Channel %s deleted.\n", args[0])
-			}
-			return nil
+			// The only DELETE under /api/v1/channels/{channel_id} is "Delete
+			// Channel Target", which requires a target_id — there is no
+			// operation that deletes a whole channel (#114). Fail fast instead
+			// of sending a request that always 422s.
+			return fmt.Errorf("deleting a channel is not supported by the Syllable API; " +
+				"to remove a target from a channel use: syllable channels targets delete <channel-id> <target-id>")
 		},
 	}
 }
@@ -465,7 +467,12 @@ func channelsTargetsDeleteCmd() *cobra.Command {
 		Short: "Delete a channel target",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			path := fmt.Sprintf("/api/v1/channels/%s/targets/%s", args[0], args[1])
+			// Delete-target is DELETE /channels/{channel_id}?target_id=<id>; the
+			// /targets/{target_id} path only supports GET/PUT (#114). The query
+			// string also suppresses the client's auto-reason param, which this
+			// operation does not declare.
+			path := fmt.Sprintf("/api/v1/channels/%s?target_id=%s",
+				url.PathEscape(args[0]), url.QueryEscape(args[1]))
 			data, _, err := apiClient.Delete(path)
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -24,6 +24,9 @@ func setupTestServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 	server := httptest.NewServer(handler)
 	apiClient = client.New(server.URL, "test-key")
 	viper.Set("output", "json")
+	// Tests run non-interactively; skip the destructive-action confirmation
+	// prompt (#118) unless a test opts back in by setting assumeYes = false.
+	assumeYes = true
 	return server
 }
 
@@ -160,7 +163,8 @@ func TestSessionsCommandHasSubcommands(t *testing.T) {
 
 func TestChannelsCommandHasSubcommands(t *testing.T) {
 	cmd := channelsCmd()
-	expected := []string{"list", "create", "update", "delete", "targets", "available-targets", "twilio"}
+	// "delete" intentionally absent — the API has no delete-channel operation (#114).
+	expected := []string{"list", "create", "update", "targets", "available-targets", "twilio"}
 	subs := make(map[string]bool)
 	for _, c := range cmd.Commands() {
 		subs[c.Name()] = true
@@ -635,7 +639,11 @@ func TestAgentsSendTestMessageOverrideTimestamp(t *testing.T) {
 // (so the CLI authenticates in CI/automation with no ~/.syllable/config.yaml).
 func TestResolveAPIKeyFromEnv(t *testing.T) {
 	t.Setenv("SYLLABLE_API_KEY", "env-key-abc123")
-	if got := resolveAPIKey(); got != "env-key-abc123" {
+	got, err := resolveAPIKey()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "env-key-abc123" {
 		t.Errorf("resolveAPIKey() = %q, want %q (SYLLABLE_API_KEY should take priority)", got, "env-key-abc123")
 	}
 }
@@ -2832,27 +2840,51 @@ func TestChannelsTargetsDeleteUsesChannelQueryParam(t *testing.T) {
 	}
 }
 
-func TestChannelsDeleteIsRejected(t *testing.T) {
+func TestDeleteRequiresConfirmation(t *testing.T) {
 	hit := false
 	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		hit = true
+		w.Write([]byte(`{}`))
 	})
 	defer server.Close()
 
-	// The API has no delete-channel operation, so the command must fail fast
-	// without issuing any request.
-	cmd := channelsDeleteCmd()
-	cmd.SetArgs([]string{"5"})
+	// Force a non-interactive stdin so the gate is deterministic regardless of
+	// whether `go test` runs from a terminal.
+	origStdin := os.Stdin
+	r, w, _ := os.Pipe()
+	w.Close() // immediate EOF
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	prev := assumeYes
+	defer func() { assumeYes = prev }()
+
+	// Without --yes and no TTY: refuse, and do not touch the server.
+	assumeYes = false
+	cmd := agentsDeleteCmd()
+	cmd.SetArgs([]string{"42"})
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 	var err error
 	captureStdout(func() { err = cmd.Execute() })
-
-	if err == nil || !strings.Contains(err.Error(), "not supported") {
-		t.Errorf("expected not-supported error, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "without confirmation") {
+		t.Errorf("expected a refusal error, got %v", err)
 	}
 	if hit {
-		t.Error("channels delete must not issue an HTTP request")
+		t.Error("delete must not issue a request without confirmation")
+	}
+
+	// With --yes: proceed and issue the request.
+	assumeYes = true
+	cmd = agentsDeleteCmd()
+	cmd.SetArgs([]string{"42"})
+	captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error with --yes: %v", err)
+		}
+	})
+	if !hit {
+		t.Error("delete with --yes should issue the request")
 	}
 }
 

--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -343,7 +343,7 @@ func TestAgentsCreateWithFlags(t *testing.T) {
 	defer server.Close()
 
 	cmd := agentsCreateCmd()
-	cmd.SetArgs([]string{"--name", "flag-agent", "--type", "inbound", "--prompt-id", "p1", "--timezone", "UTC"})
+	cmd.SetArgs([]string{"--name", "flag-agent", "--type", "inbound", "--prompt-id", "7", "--timezone", "UTC"})
 	captureStdout(func() {
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -352,6 +352,10 @@ func TestAgentsCreateWithFlags(t *testing.T) {
 
 	if receivedBody["name"] != "flag-agent" {
 		t.Errorf("expected name=flag-agent, got %v", receivedBody["name"])
+	}
+	// prompt_id must be sent as a JSON number, not a string (#116).
+	if receivedBody["prompt_id"] != float64(7) {
+		t.Errorf("expected prompt_id=7 (number), got %#v", receivedBody["prompt_id"])
 	}
 	// Verify default empty maps are included
 	if receivedBody["variables"] == nil {
@@ -696,13 +700,19 @@ func TestToolsCreateWithFlags(t *testing.T) {
 	defer server.Close()
 
 	cmd := toolsCreateCmd()
-	cmd.SetArgs([]string{"--name", "my_tool", "--service-id", "svc-1"})
+	cmd.SetArgs([]string{"--name", "my_tool", "--service-id", "1"})
 	captureStdout(func() {
-		cmd.Execute()
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 	})
 
 	if receivedBody["name"] != "my_tool" {
 		t.Errorf("expected name=my_tool, got %v", receivedBody["name"])
+	}
+	// service_id must be sent as a JSON number, not a string (#116).
+	if receivedBody["service_id"] != float64(1) {
+		t.Errorf("expected service_id=1 (number), got %#v", receivedBody["service_id"])
 	}
 	if receivedBody["definition"] == nil {
 		t.Error("expected empty definition map in body")
@@ -712,9 +722,12 @@ func TestToolsCreateWithFlags(t *testing.T) {
 // --- Sessions functional tests ---
 
 func TestSessionsList(t *testing.T) {
-	var requestPath string
+	var startVal, endVal string
 	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-		requestPath = r.URL.String()
+		// Read the decoded query values so the assertion is independent of
+		// escaping style and proves the value round-trips intact (#116).
+		startVal = r.URL.Query().Get("start_datetime")
+		endVal = r.URL.Query().Get("end_datetime")
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"items":       []interface{}{},
 			"total_count": 0,
@@ -722,17 +735,19 @@ func TestSessionsList(t *testing.T) {
 	})
 	defer server.Close()
 
+	// A non-UTC offset contains "+", which is corrupted to a space unless the
+	// value is URL-escaped — the exact bug this guards against.
 	cmd := sessionsListCmd()
-	cmd.SetArgs([]string{"--start-date", "2024-01-01T00:00:00Z", "--end-date", "2024-01-31T23:59:59Z"})
+	cmd.SetArgs([]string{"--start-date", "2024-01-01T00:00:00+05:00", "--end-date", "2024-01-31T23:59:59Z"})
 	captureStdout(func() {
 		cmd.Execute()
 	})
 
-	if !strings.Contains(requestPath, "start_datetime=2024-01-01T00:00:00Z") {
-		t.Errorf("expected start_datetime in path, got: %s", requestPath)
+	if startVal != "2024-01-01T00:00:00+05:00" {
+		t.Errorf("start_datetime not round-tripped, got: %q", startVal)
 	}
-	if !strings.Contains(requestPath, "end_datetime=2024-01-31T23:59:59Z") {
-		t.Errorf("expected end_datetime in path, got: %s", requestPath)
+	if endVal != "2024-01-31T23:59:59Z" {
+		t.Errorf("end_datetime not round-tripped, got: %q", endVal)
 	}
 }
 
@@ -2727,5 +2742,132 @@ func TestChannelsGetNotFound(t *testing.T) {
 
 	if err == nil || !strings.Contains(err.Error(), "syllable channels list") {
 		t.Errorf("expected not-found error pointing at channels list, got %v", err)
+	}
+}
+
+// --- API-contract regression tests (#114, #115) ---
+
+func TestUsersDeleteSendsJSONBody(t *testing.T) {
+	var method, path string
+	var body map[string]interface{}
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		path = r.URL.Path
+		json.NewDecoder(r.Body).Decode(&body)
+		w.Write([]byte(`{}`))
+	})
+	defer server.Close()
+
+	cmd := usersDeleteCmd()
+	cmd.SetArgs([]string{"alice@example.com"})
+	captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if method != http.MethodDelete || path != "/api/v1/users/" {
+		t.Errorf("expected DELETE /api/v1/users/, got %s %s", method, path)
+	}
+	if body["email"] != "alice@example.com" {
+		t.Errorf("expected email in body, got %#v", body["email"])
+	}
+	if body["reason"] == nil || body["reason"] == "" {
+		t.Errorf("expected a non-empty reason in body, got %#v", body["reason"])
+	}
+}
+
+func TestChannelsUpdateRoutesToCollection(t *testing.T) {
+	var method, path string
+	var body map[string]interface{}
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		path = r.URL.Path
+		json.NewDecoder(r.Body).Decode(&body)
+		w.Write([]byte(`{}`))
+	})
+	defer server.Close()
+
+	// PUT must hit the collection path, and the positional id must be injected
+	// into the body since the API routes by it.
+	cmd := channelsUpdateCmd()
+	cmd.SetArgs([]string{"5", "--file", writeTempJSON(t, `{"name":"main","channel_service":"twilio","config":{}}`)})
+	captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if method != http.MethodPut || path != "/api/v1/channels/" {
+		t.Errorf("expected PUT /api/v1/channels/, got %s %s", method, path)
+	}
+	if body["id"] != float64(5) {
+		t.Errorf("expected id=5 injected into body, got %#v", body["id"])
+	}
+}
+
+func TestChannelsTargetsDeleteUsesChannelQueryParam(t *testing.T) {
+	var method, path, target string
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		path = r.URL.Path
+		target = r.URL.Query().Get("target_id")
+		w.Write([]byte(``))
+	})
+	defer server.Close()
+
+	cmd := channelsTargetsDeleteCmd()
+	cmd.SetArgs([]string{"5", "42"})
+	captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if method != http.MethodDelete || path != "/api/v1/channels/5" {
+		t.Errorf("expected DELETE /api/v1/channels/5, got %s %s", method, path)
+	}
+	if target != "42" {
+		t.Errorf("expected target_id=42 query param, got %q", target)
+	}
+}
+
+func TestChannelsDeleteIsRejected(t *testing.T) {
+	hit := false
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+	})
+	defer server.Close()
+
+	// The API has no delete-channel operation, so the command must fail fast
+	// without issuing any request.
+	cmd := channelsDeleteCmd()
+	cmd.SetArgs([]string{"5"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	var err error
+	captureStdout(func() { err = cmd.Execute() })
+
+	if err == nil || !strings.Contains(err.Error(), "not supported") {
+		t.Errorf("expected not-supported error, got %v", err)
+	}
+	if hit {
+		t.Error("channels delete must not issue an HTTP request")
+	}
+}
+
+func TestValidateOutputFmt(t *testing.T) {
+	prev := viper.GetString("output")
+	defer viper.Set("output", prev)
+
+	for _, ok := range []string{"table", "json", ""} {
+		viper.Set("output", ok)
+		if err := validateOutputFmt(); err != nil {
+			t.Errorf("validateOutputFmt(%q) = %v, want nil", ok, err)
+		}
+	}
+	viper.Set("output", "yaml")
+	if err := validateOutputFmt(); err == nil {
+		t.Error(`validateOutputFmt("yaml") = nil, want error`)
 	}
 }

--- a/scripts/syllable-cli/cmd/custom_messages.go
+++ b/scripts/syllable-cli/cmd/custom_messages.go
@@ -253,6 +253,9 @@ func customMessagesDeleteCmd() *cobra.Command {
 		Short: "Delete a custom message",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := confirmDelete(cmd, args); err != nil {
+				return err
+			}
 			data, _, err := apiClient.Delete("/api/v1/custom_messages/" + args[0])
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/data_sources.go
+++ b/scripts/syllable-cli/cmd/data_sources.go
@@ -237,6 +237,9 @@ func dataSourcesDeleteCmd() *cobra.Command {
 		Short: "Delete a data source",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := confirmDelete(cmd, args); err != nil {
+				return err
+			}
 			data, _, err := apiClient.Delete("/api/v1/data_sources/" + args[0])
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/directory.go
+++ b/scripts/syllable-cli/cmd/directory.go
@@ -259,6 +259,9 @@ func directoryDeleteCmd() *cobra.Command {
 		Short: "Delete a directory member",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := confirmDelete(cmd, args); err != nil {
+				return err
+			}
 			data, _, err := apiClient.Delete("/api/v1/directory_members/" + args[0] + "?comment=deleted+via+cli")
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/incidents.go
+++ b/scripts/syllable-cli/cmd/incidents.go
@@ -203,6 +203,9 @@ func incidentsDeleteCmd() *cobra.Command {
 		Short: "Delete an incident",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := confirmDelete(cmd, args); err != nil {
+				return err
+			}
 			data, _, err := apiClient.Delete("/api/v1/incidents/" + args[0])
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/insights.go
+++ b/scripts/syllable-cli/cmd/insights.go
@@ -337,6 +337,9 @@ func insightsWorkflowsDeleteCmd() *cobra.Command {
 		Short: "Delete an insight workflow",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := confirmDelete(cmd, args); err != nil {
+				return err
+			}
 			data, _, err := apiClient.Delete("/api/v1/insights/workflows/" + args[0])
 			if err != nil {
 				return err
@@ -602,6 +605,9 @@ func insightsFoldersDeleteCmd() *cobra.Command {
 		Short: "Delete an insight folder",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := confirmDelete(cmd, args); err != nil {
+				return err
+			}
 			data, _, err := apiClient.Delete("/api/v1/insights/folders/" + args[0])
 			if err != nil {
 				return err
@@ -836,6 +842,9 @@ func insightsToolConfigsDeleteCmd() *cobra.Command {
 		Short: "Delete an insight tool configuration",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := confirmDelete(cmd, args); err != nil {
+				return err
+			}
 			data, _, err := apiClient.Delete("/api/v1/insights/tool-configurations/" + args[0])
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/insights.go
+++ b/scripts/syllable-cli/cmd/insights.go
@@ -434,7 +434,7 @@ func insightsFoldersListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := fmt.Sprintf("/api/v1/insights/folders/?page=%d&limit=%d", page, limit)
 			if search != "" {
-				path += fmt.Sprintf("&search_fields=name&search_field_values=%s", search)
+				path += fmt.Sprintf("&search_fields=name&search_field_values=%s", url.QueryEscape(search))
 			}
 
 			data, _, err := apiClient.Get(path)

--- a/scripts/syllable-cli/cmd/language_groups.go
+++ b/scripts/syllable-cli/cmd/language_groups.go
@@ -236,6 +236,9 @@ func languageGroupsDeleteCmd() *cobra.Command {
 		Short: "Delete a language group",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := confirmDelete(cmd, args); err != nil {
+				return err
+			}
 			data, _, err := apiClient.Delete("/api/v1/language_groups/" + args[0])
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/organizations.go
+++ b/scripts/syllable-cli/cmd/organizations.go
@@ -233,6 +233,9 @@ func organizationsSipIPRangesDeleteCmd() *cobra.Command {
 		Short: "Delete a SIP IP range",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := confirmDelete(cmd, args); err != nil {
+				return err
+			}
 			path := fmt.Sprintf("/api/v1/organizations/sip_ip_ranges/%s", args[0])
 			data, _, err := apiClient.Delete(path)
 			if err != nil {

--- a/scripts/syllable-cli/cmd/outbound.go
+++ b/scripts/syllable-cli/cmd/outbound.go
@@ -286,6 +286,9 @@ func outboundBatchesDeleteCmd() *cobra.Command {
 		Short: "Delete an outbound batch",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := confirmDelete(cmd, args); err != nil {
+				return err
+			}
 			data, _, err := apiClient.DeleteWithForm("/api/v1/outbound/batches/"+args[0], map[string]string{"delete_reason": reason})
 			if err != nil {
 				return err
@@ -656,6 +659,9 @@ func outboundCampaignsDeleteCmd() *cobra.Command {
 		Short: "Delete an outbound campaign",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := confirmDelete(cmd, args); err != nil {
+				return err
+			}
 			data, _, err := apiClient.Delete("/api/v1/outbound/campaigns/" + args[0])
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/outbound.go
+++ b/scripts/syllable-cli/cmd/outbound.go
@@ -214,9 +214,13 @@ func outboundBatchesCreateCmd() *cobra.Command {
 				if batchID == "" || campaignID == "" {
 					return fmt.Errorf("required flags: --batch-id, --campaign-id (or use --file)")
 				}
+				campaignIDInt, err := parseIDFlag("campaign-id", campaignID)
+				if err != nil {
+					return err
+				}
 				body = map[string]interface{}{
 					"batch_id":    batchID,
-					"campaign_id": campaignID,
+					"campaign_id": campaignIDInt,
 					"paused":      paused,
 				}
 			}

--- a/scripts/syllable-cli/cmd/prompts.go
+++ b/scripts/syllable-cli/cmd/prompts.go
@@ -252,6 +252,9 @@ func promptsDeleteCmd() *cobra.Command {
 		Short: "Delete a prompt",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := confirmDelete(cmd, args); err != nil {
+				return err
+			}
 			data, _, err := apiClient.Delete("/api/v1/prompts/" + args[0])
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/roles.go
+++ b/scripts/syllable-cli/cmd/roles.go
@@ -232,6 +232,9 @@ func rolesDeleteCmd() *cobra.Command {
 		Short: "Delete a role",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := confirmDelete(cmd, args); err != nil {
+				return err
+			}
 			data, _, err := apiClient.Delete("/api/v1/roles/" + args[0])
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/root.go
+++ b/scripts/syllable-cli/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -28,6 +29,7 @@ var (
 	dryRun     bool
 	debugMode  bool
 	fieldsFlag string
+	assumeYes  bool
 	apiClient  *client.Client
 )
 
@@ -74,8 +76,7 @@ Feedback: https://github.com/asksyllable/syllable-cli/issues`,
 		if cmd.Root() == cmd && len(args) == 0 {
 			return nil
 		}
-		initClient()
-		return nil
+		return initClient()
 	},
 }
 
@@ -255,6 +256,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "Print the request that would be sent without executing it")
 	rootCmd.PersistentFlags().BoolVar(&debugMode, "debug", false, "Print HTTP request and response details to stderr")
 	rootCmd.PersistentFlags().StringVar(&fieldsFlag, "fields", "", "Comma-separated columns to show in table output (e.g. id,name,type)")
+	rootCmd.PersistentFlags().BoolVarP(&assumeYes, "yes", "y", false, "Skip the confirmation prompt on destructive commands (for non-interactive use)")
 
 	// Bind flags to viper
 	viper.BindPFlag("org", rootCmd.PersistentFlags().Lookup("org"))
@@ -314,28 +316,37 @@ func initConfig() {
 	viper.ReadInConfig()
 }
 
-func initClient() {
-	url := resolveBaseURL()
-	key := resolveAPIKey()
+func initClient() error {
+	url, err := resolveBaseURL()
+	if err != nil {
+		return err
+	}
+	key, err := resolveAPIKey()
+	if err != nil {
+		return err
+	}
 
 	if key == "" {
-		fmt.Fprintln(os.Stderr, "Error: not configured. Run `syllable setup` and select an org with --org <name>, or set SYLLABLE_API_KEY for non-interactive use.")
-		os.Exit(1)
+		return errors.New("not configured — run `syllable setup` and select an org with --org <name>, or set SYLLABLE_API_KEY for non-interactive use")
 	}
 
 	apiClient = client.New(url, key)
 	apiClient.DryRun = dryRun
 	apiClient.Verbose = debugMode
+	return nil
 }
 
 // resolveAPIKey determines the API key to use from config.
 // Priority: orgs.<org>.envs.<env>.api_key > orgs.<org>.api_key
-// Org is taken from --org flag or default_org in config.
-func resolveAPIKey() string {
+// Org is taken from --org flag or default_org in config. It returns "" with a
+// nil error when nothing is configured, so the caller can render a single
+// "not configured" message; config problems (unknown org, missing key) are
+// returned as errors that flow through the normal --output json error path (#128).
+func resolveAPIKey() (string, error) {
 	// Non-interactive auth: an explicit key in the environment takes priority,
 	// so the CLI works in CI and automation without a ~/.syllable/config.yaml.
 	if k := os.Getenv("SYLLABLE_API_KEY"); k != "" {
-		return k
+		return k, nil
 	}
 
 	org := strings.ToLower(viper.GetString("org"))
@@ -344,19 +355,17 @@ func resolveAPIKey() string {
 	}
 
 	if org == "" {
-		return ""
+		return "", nil
 	}
 
 	orgs := viper.GetStringMap("orgs")
 	orgData, ok := orgs[org]
 	if !ok {
-		fmt.Fprintf(os.Stderr, "Error: org %q not found in ~/.syllable/config.yaml — run `syllable setup` to add it\n", org)
-		os.Exit(1)
+		return "", fmt.Errorf("org %q not found in ~/.syllable/config.yaml — run `syllable setup` to add it", org)
 	}
 	orgMap, ok := orgData.(map[string]interface{})
 	if !ok {
-		fmt.Fprintf(os.Stderr, "Error: invalid config for org %q in ~/.syllable/config.yaml\n", org)
-		os.Exit(1)
+		return "", fmt.Errorf("invalid config for org %q in ~/.syllable/config.yaml", org)
 	}
 
 	// env-specific key: orgs.<org>.envs.<env>.api_key
@@ -364,7 +373,7 @@ func resolveAPIKey() string {
 		if envs, ok := orgMap["envs"].(map[string]interface{}); ok {
 			if envData, ok := envs[env].(map[string]interface{}); ok {
 				if k, _ := envData["api_key"].(string); k != "" {
-					return k
+					return k, nil
 				}
 			}
 		}
@@ -380,13 +389,11 @@ func resolveAPIKey() string {
 				names = append(names, e)
 			}
 			sort.Strings(names)
-			fmt.Fprintf(os.Stderr, "Error: org %q has per-environment keys (%s) but no environment was specified.\nUse --env <name> or set default_env in `syllable setup`.\n", org, strings.Join(names, ", "))
-		} else {
-			fmt.Fprintf(os.Stderr, "Error: no api_key found for org %q — run `syllable setup` to configure it\n", org)
+			return "", fmt.Errorf("org %q has per-environment keys (%s) but no environment was specified — use --env <name> or set default_env in `syllable setup`", org, strings.Join(names, ", "))
 		}
-		os.Exit(1)
+		return "", fmt.Errorf("no api_key found for org %q — run `syllable setup` to configure it", org)
 	}
-	return k
+	return k, nil
 }
 
 // resolveEnvName returns the active environment name from --env flag, SYLLABLE_ENV,
@@ -400,7 +407,7 @@ func resolveEnvName() string {
 
 // resolveBaseURL determines the base URL from config.
 // Priority: --env config lookup > --env builtin alias (prod) > https://api.syllable.cloud
-func resolveBaseURL() string {
+func resolveBaseURL() (string, error) {
 	env := resolveEnvName()
 	if env != "" {
 		// Check config-defined environments first
@@ -408,20 +415,19 @@ func resolveBaseURL() string {
 		if envData, ok := environments[env]; ok {
 			if envMap, ok := envData.(map[string]interface{}); ok {
 				if u, _ := envMap["base_url"].(string); u != "" {
-					return u
+					return u, nil
 				}
 			}
 		}
 		// Built-in alias: prod
 		if env == "prod" {
-			return "https://api.syllable.cloud"
+			return "https://api.syllable.cloud", nil
 		}
-		// Unknown env — exit with a clear error
-		fmt.Fprintf(os.Stderr, "Error: environment %q not found in ~/.syllable/config.yaml — add it with `syllable setup`\n", env)
-		os.Exit(1)
+		// Unknown env — surface a clear error through the normal error path.
+		return "", fmt.Errorf("environment %q not found in ~/.syllable/config.yaml — add it with `syllable setup`", env)
 	}
 
-	return "https://api.syllable.cloud"
+	return "https://api.syllable.cloud", nil
 }
 
 func getOutputFmt() string {
@@ -491,6 +497,44 @@ func parseIDFlag(flagName, value string) (int64, error) {
 		return 0, fmt.Errorf("--%s must be a whole number, got %q", flagName, value)
 	}
 	return n, nil
+}
+
+// confirmDelete prompts for confirmation before a destructive command runs (#118).
+// It returns nil — proceed without prompting — when --yes is set or --dry-run is
+// in effect (dry-run never executes the call). When stdin is not a terminal and
+// --yes was not passed, it refuses with an actionable error so scripts can't
+// delete by accident; otherwise it asks for y/N on stderr and reads the answer
+// from stdin. The target shown is derived from the command path and positional
+// args, e.g. "syllable agents delete 42".
+func confirmDelete(cmd *cobra.Command, args []string) error {
+	if assumeYes || dryRun {
+		return nil
+	}
+	target := cmd.CommandPath()
+	if len(args) > 0 {
+		target += " " + strings.Join(args, " ")
+	}
+	if !isStdinTTY() {
+		return fmt.Errorf("refusing to run %q without confirmation; pass --yes to confirm non-interactively", target)
+	}
+	fmt.Fprintf(os.Stderr, "About to run: %s\nThis is destructive and cannot be undone. Continue? [y/N]: ", target)
+	line, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return nil
+	default:
+		return fmt.Errorf("aborted")
+	}
+}
+
+// isStdinTTY reports whether stdin is connected to a terminal (vs a pipe/file),
+// used to decide whether an interactive confirmation prompt is possible.
+func isStdinTTY() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
 }
 
 // identifierMatches compares a JSON body value against a positional CLI string.

--- a/scripts/syllable-cli/cmd/root.go
+++ b/scripts/syllable-cli/cmd/root.go
@@ -61,6 +61,9 @@ Feedback: https://github.com/asksyllable/syllable-cli/issues`,
 		if cmd == nil {
 			return nil
 		}
+		if err := validateOutputFmt(); err != nil {
+			return err
+		}
 		// Skip for commands that don't need auth. Cobra invokes this for each command in
 		// the chain (root → completion → zsh); for the leaf we see cmd.Name()=="zsh", so
 		// check this command and all ancestors. Also skip when root runs with no args
@@ -425,6 +428,18 @@ func getOutputFmt() string {
 	return viper.GetString("output")
 }
 
+// validateOutputFmt rejects --output values other than table or json, so a typo
+// like `-o jsno` fails loudly instead of silently rendering a table into a
+// script that expected JSON (#119).
+func validateOutputFmt() error {
+	switch getOutputFmt() {
+	case "", "table", "json":
+		return nil
+	default:
+		return fmt.Errorf("invalid --output %q: must be \"table\" or \"json\"", getOutputFmt())
+	}
+}
+
 // readFile reads a file by path, or reads from stdin if path is "-".
 func readFile(path string) ([]byte, error) {
 	if path == "-" {
@@ -466,6 +481,18 @@ func ensureBodyIdentifier(body interface{}, key, positional string, numeric bool
 	return nil
 }
 
+// parseIDFlag converts a string flag whose value the API expects as a JSON
+// integer. Inline create bodies historically sent these as strings, which only
+// worked while the backend coerced them; sending the right type also yields a
+// clearer error than a server-side 422 (#116).
+func parseIDFlag(flagName, value string) (int64, error) {
+	n, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("--%s must be a whole number, got %q", flagName, value)
+	}
+	return n, nil
+}
+
 // identifierMatches compares a JSON body value against a positional CLI string.
 func identifierMatches(existing interface{}, positional string) bool {
 	switch v := existing.(type) {
@@ -484,7 +511,11 @@ func identifierMatches(existing interface{}, positional string) bool {
 func printTable(headers []string, rows [][]string) {
 	if fieldsFlag != "" {
 		fields := strings.Split(fieldsFlag, ",")
-		headers, rows = output.FilterColumns(headers, rows, fields)
+		var unknown []string
+		headers, rows, unknown = output.FilterColumns(headers, rows, fields)
+		if len(unknown) > 0 {
+			fmt.Fprintf(os.Stderr, "warning: unknown --fields column(s): %s\n", strings.Join(unknown, ", "))
+		}
 	}
 	output.PrintTable(headers, rows)
 }

--- a/scripts/syllable-cli/cmd/schema.go
+++ b/scripts/syllable-cli/cmd/schema.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
@@ -100,8 +99,7 @@ func schemaGetCmd() *cobra.Command {
 				}
 			}
 			if !ok {
-				fmt.Fprintf(os.Stderr, "Schema %q not found. Run `syllable schema list` to see available schemas.\n", args[0])
-				os.Exit(1)
+				return fmt.Errorf("schema %q not found — run `syllable schema list` to see available schemas", args[0])
 			}
 
 			b, err := json.MarshalIndent(schema, "", "  ")

--- a/scripts/syllable-cli/cmd/services.go
+++ b/scripts/syllable-cli/cmd/services.go
@@ -233,6 +233,9 @@ func servicesDeleteCmd() *cobra.Command {
 		Short: "Delete a service",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := confirmDelete(cmd, args); err != nil {
+				return err
+			}
 			data, _, err := apiClient.Delete("/api/v1/services/" + args[0])
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/sessions.go
+++ b/scripts/syllable-cli/cmd/sessions.go
@@ -100,10 +100,10 @@ func sessionsListCmd() *cobra.Command {
 				path += fmt.Sprintf("&search_fields=%s&search_field_values=%s", searchField, url.QueryEscape(search))
 			}
 			if startDate != "" {
-				path += fmt.Sprintf("&start_datetime=%s", startDate)
+				path += fmt.Sprintf("&start_datetime=%s", url.QueryEscape(startDate))
 			}
 			if endDate != "" {
-				path += fmt.Sprintf("&end_datetime=%s", endDate)
+				path += fmt.Sprintf("&end_datetime=%s", url.QueryEscape(endDate))
 			}
 			if includeTest {
 				path += "&search_fields=is_test&search_field_values=true"

--- a/scripts/syllable-cli/cmd/tools.go
+++ b/scripts/syllable-cli/cmd/tools.go
@@ -371,6 +371,9 @@ func toolsDeleteCmd() *cobra.Command {
 		Short: "Delete a tool",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := confirmDelete(cmd, args); err != nil {
+				return err
+			}
 			data, _, err := apiClient.Delete("/api/v1/tools/" + args[0])
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/tools.go
+++ b/scripts/syllable-cli/cmd/tools.go
@@ -295,9 +295,13 @@ func toolsCreateCmd() *cobra.Command {
 				if name == "" || serviceID == "" {
 					return fmt.Errorf("required flags: --name, --service-id (or use --file)")
 				}
+				serviceIDInt, err := parseIDFlag("service-id", serviceID)
+				if err != nil {
+					return err
+				}
 				body = map[string]interface{}{
 					"name":       name,
-					"service_id": serviceID,
+					"service_id": serviceIDInt,
 					"definition": map[string]interface{}{},
 				}
 			}

--- a/scripts/syllable-cli/cmd/users.go
+++ b/scripts/syllable-cli/cmd/users.go
@@ -246,9 +246,13 @@ func usersCreateCmd() *cobra.Command {
 				if email == "" || roleID == "" {
 					return fmt.Errorf("required flags: --email, --role-id (or use --file)")
 				}
+				roleIDInt, err := parseIDFlag("role-id", roleID)
+				if err != nil {
+					return err
+				}
 				body = map[string]interface{}{
 					"email":      email,
-					"role_id":    roleID,
+					"role_id":    roleIDInt,
 					"first_name": firstName,
 					"last_name":  lastName,
 				}
@@ -320,9 +324,13 @@ func usersDeleteCmd() *cobra.Command {
 		Short: "Delete a user",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Delete uses query param per the spec
-			path := fmt.Sprintf("/api/v1/users/?email=%s", args[0])
-			data, _, err := apiClient.Delete(path)
+			// DELETE /api/v1/users/ takes a JSON body (email + reason both
+			// required), not a query param (#115).
+			body := map[string]interface{}{
+				"email":  args[0],
+				"reason": "deleted via cli",
+			}
+			data, _, err := apiClient.DeleteWithBody("/api/v1/users/", body)
 			if err != nil {
 				return err
 			}

--- a/scripts/syllable-cli/cmd/users.go
+++ b/scripts/syllable-cli/cmd/users.go
@@ -324,6 +324,9 @@ func usersDeleteCmd() *cobra.Command {
 		Short: "Delete a user",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := confirmDelete(cmd, args); err != nil {
+				return err
+			}
 			// DELETE /api/v1/users/ takes a JSON body (email + reason both
 			// required), not a query param (#115).
 			body := map[string]interface{}{

--- a/scripts/syllable-cli/cmd/voice_groups.go
+++ b/scripts/syllable-cli/cmd/voice_groups.go
@@ -271,6 +271,9 @@ func voiceGroupsDeleteCmd() *cobra.Command {
 		Short: "Delete a voice group",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := confirmDelete(cmd, args); err != nil {
+				return err
+			}
 			data, _, err := apiClient.Delete("/api/v1/voice_groups/" + args[0])
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/internal/client/client.go
+++ b/scripts/syllable-cli/internal/client/client.go
@@ -235,14 +235,13 @@ func (c *Client) DeleteWithBody(path string, body interface{}) ([]byte, int, err
 	return c.Do(http.MethodDelete, path, body)
 }
 
-// PostWithTimeout performs a POST request with a custom timeout.
-// It uses a temporary http.Client rather than mutating the shared one,
-// so it is safe to call concurrently.
+// PostWithTimeout performs a POST request with a custom timeout. It runs the
+// request through a shallow copy of the client that has its own http.Client, so
+// it never mutates the shared client's timeout and is safe to call concurrently (#132).
 func (c *Client) PostWithTimeout(path string, body interface{}, timeout time.Duration) ([]byte, int, error) {
-	orig := c.HTTPClient
-	c.HTTPClient = &http.Client{Timeout: timeout}
-	defer func() { c.HTTPClient = orig }()
-	return c.Do(http.MethodPost, path, body)
+	tmp := *c
+	tmp.HTTPClient = &http.Client{Timeout: timeout}
+	return tmp.Do(http.MethodPost, path, body)
 }
 
 // PostMultipart performs a multipart/form-data POST, uploading a local file as the named field.

--- a/scripts/syllable-cli/internal/output/output.go
+++ b/scripts/syllable-cli/internal/output/output.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"text/tabwriter"
+	"unicode/utf8"
 )
 
 // PrintTable prints data as a formatted table using tab-separated columns.
@@ -59,9 +60,10 @@ func PrintJSON(data []byte) {
 }
 
 // FilterColumns filters headers and rows to only the requested column names (case-insensitive).
-// Columns are returned in the order specified by fields. Unknown field names are ignored.
-// If no valid fields are matched, the original headers and rows are returned unchanged.
-func FilterColumns(headers []string, rows [][]string, fields []string) ([]string, [][]string) {
+// Columns are returned in the order specified by fields. The names of any requested fields that
+// don't match a header are returned in unknown so the caller can warn (#120). If no valid fields
+// are matched, the original headers and rows are returned unchanged (with unknown still populated).
+func FilterColumns(headers []string, rows [][]string, fields []string) (filteredHeaders []string, filteredRows [][]string, unknown []string) {
 	// Map lowercase header name -> column index
 	index := make(map[string]int, len(headers))
 	for i, h := range headers {
@@ -69,19 +71,24 @@ func FilterColumns(headers []string, rows [][]string, fields []string) ([]string
 	}
 
 	var keep []int
-	var filteredHeaders []string
 	for _, f := range fields {
-		if idx, ok := index[strings.ToLower(strings.TrimSpace(f))]; ok {
+		trimmed := strings.TrimSpace(f)
+		if trimmed == "" {
+			continue
+		}
+		if idx, ok := index[strings.ToLower(trimmed)]; ok {
 			keep = append(keep, idx)
 			filteredHeaders = append(filteredHeaders, headers[idx])
+		} else {
+			unknown = append(unknown, trimmed)
 		}
 	}
 
 	if len(keep) == 0 {
-		return headers, rows
+		return headers, rows, unknown
 	}
 
-	filteredRows := make([][]string, len(rows))
+	filteredRows = make([][]string, len(rows))
 	for i, row := range rows {
 		filtered := make([]string, len(keep))
 		for j, idx := range keep {
@@ -92,16 +99,19 @@ func FilterColumns(headers []string, rows [][]string, fields []string) ([]string
 		filteredRows[i] = filtered
 	}
 
-	return filteredHeaders, filteredRows
+	return filteredHeaders, filteredRows, unknown
 }
 
-// Truncate truncates a string to max length, appending "..." if needed.
+// Truncate truncates a string to max runes, appending "..." if needed.
+// It counts and slices by rune, not byte, so multibyte UTF-8 (e.g. Mandarin,
+// Korean, Cyrillic transcripts) is never split mid-character (#131).
 func Truncate(s string, max int) string {
-	if len(s) <= max {
+	if utf8.RuneCountInString(s) <= max {
 		return s
 	}
+	r := []rune(s)
 	if max <= 3 {
-		return s[:max]
+		return string(r[:max])
 	}
-	return s[:max-3] + "..."
+	return string(r[:max-3]) + "..."
 }

--- a/scripts/syllable-cli/internal/output/output_test.go
+++ b/scripts/syllable-cli/internal/output/output_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 // captureStdout captures stdout output from a function call.
@@ -48,6 +49,62 @@ func TestTruncate(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("Truncate(%q, %d) = %q, want %q", tt.input, tt.max, got, tt.want)
 		}
+	}
+}
+
+func TestTruncateMultibyteUTF8(t *testing.T) {
+	// Each rune here is multiple bytes; byte-slicing would split one mid-rune
+	// and emit invalid UTF-8 (#131).
+	tests := []struct {
+		input string
+		max   int
+		want  string
+	}{
+		{"日本語テキスト", 4, "日..."},     // 7 runes -> r[:1] + "..."
+		{"日本語テキスト", 7, "日本語テキスト"},  // fits exactly by rune count
+		{"Привет мир", 5, "Пр..."}, // Cyrillic
+		{"한국어", 1, "한"},            // max<=3 path, no ellipsis
+	}
+	for _, tt := range tests {
+		got := Truncate(tt.input, tt.max)
+		if got != tt.want {
+			t.Errorf("Truncate(%q, %d) = %q, want %q", tt.input, tt.max, got, tt.want)
+		}
+		if !utf8.ValidString(got) {
+			t.Errorf("Truncate(%q, %d) = %q is not valid UTF-8", tt.input, tt.max, got)
+		}
+	}
+}
+
+func TestFilterColumns(t *testing.T) {
+	headers := []string{"ID", "NAME", "TYPE"}
+	rows := [][]string{{"1", "alpha", "x"}, {"2", "beta", "y"}}
+
+	// Case-insensitive match, reordered by request, unknown names reported.
+	h, r, unknown := FilterColumns(headers, rows, []string{"name", "id", "bogus"})
+	if strings.Join(h, ",") != "NAME,ID" {
+		t.Errorf("expected NAME,ID, got %v", h)
+	}
+	if r[0][0] != "alpha" || r[0][1] != "1" {
+		t.Errorf("expected reordered row [alpha 1], got %v", r[0])
+	}
+	if len(unknown) != 1 || unknown[0] != "bogus" {
+		t.Errorf("expected unknown=[bogus], got %v", unknown)
+	}
+
+	// All-unknown → original table returned unchanged, unknowns still reported.
+	h, r, unknown = FilterColumns(headers, rows, []string{"nope"})
+	if len(h) != 3 || len(r) != 2 {
+		t.Errorf("expected original table on zero matches, got headers=%v rows=%v", h, r)
+	}
+	if len(unknown) != 1 || unknown[0] != "nope" {
+		t.Errorf("expected unknown=[nope], got %v", unknown)
+	}
+
+	// A short row is padded, not panicking.
+	h, r, _ = FilterColumns(headers, [][]string{{"1"}}, []string{"id", "type"})
+	if len(r[0]) != 2 || r[0][0] != "1" || r[0][1] != "" {
+		t.Errorf("expected padded row [1 \"\"], got %v", r[0])
 	}
 }
 


### PR DESCRIPTION
First implementation batch from the full code review (epics #144–149). **9 issues**, two commits, all covered by new or updated unit tests. `go build`, `go vet`, and `go test -race` are green.

## API contract — commands that could not succeed against the embedded spec
- **#114** — `channels update` now uses the collection PUT (`/api/v1/channels/`) with the positional id reconciled into the body; `channels targets delete` now uses `DELETE /channels/{id}?target_id=…`; **`channels delete` removed entirely** — the API has no delete-channel operation (only "Delete Channel Target"), and `channels targets delete` covers target removal.
- **#115** — `users delete` sends the required JSON body (`email` + `reason`) instead of an unsupported `?email=` query param.
- **#116** — `prompt_id`/`service_id`/`role_id`/`campaign_id` are sent as JSON integers, not strings; `sessions list` dates and `insights folders` search are URL-escaped.

## Safety & UX
- **#118** — destructive deletes now confirm. A global `--yes`/`-y` flag plus a `confirmDelete` gate on all 19 resource-delete commands: interactive runs get a `y/N` prompt, non-interactive runs (no TTY) refuse unless `--yes` is passed, and `--dry-run` bypasses the prompt. (`delete-account` and the pronunciation CSV commands keep their existing `--confirm`.)
- **#119** — `--output` is validated; an invalid value errors instead of silently rendering a table into a script expecting JSON.
- **#120** — `--fields` warns on stderr for unknown columns instead of silently dropping them.

## Reliability
- **#128** — config/auth failures (unknown org, missing key, unknown env, schema not found) now return errors through `Execute`/`printError` instead of calling `os.Exit` deep in a helper. With `--output json` they emit the structured `{"error":{…}}` envelope the automation parses, instead of a bare line. `resolveAPIKey`/`resolveBaseURL`/`initClient` now return errors, which also makes their precedence logic unit-testable.
- **#131** — `output.Truncate` slices by rune, not byte, so multibyte transcripts (Mandarin/Korean/Cyrillic) are never split mid-character.
- **#132** — `client.PostWithTimeout` uses a shallow copy instead of mutating the shared HTTP client, matching its doc comment.

## Notes for the reviewer
- **Docs**: the `channels delete` references in AGENTS.md/README.md are removed in my working tree but left out of this PR because those files carry other in-progress edits; the broader doc-accuracy sweep is tracked in **#122**.
- **Formatting**: the repo-wide `gofmt` drift is intentionally untouched here — only my own new lines are formatted. The one-time `gofmt -w` plus a CI format gate is tracked in **#135** (and depends on the Go-version bump there).

Closes #114, #115, #116, #118, #119, #120, #128, #131, #132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
