### PR TITLE
Code review batch 3: path/query escaping + setup/install/config hardening

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -64,7 +64,9 @@ if command -v sha256sum >/dev/null 2>&1; then
 elif command -v shasum >/dev/null 2>&1; then
   grep "$FILENAME" "$CHECKSUM_FILE" | shasum -a 256 -c --quiet
 else
-  echo "Warning: could not verify checksum (sha256sum/shasum not found)"
+  echo "Error: cannot verify download — neither sha256sum nor shasum is available." >&2
+  echo "Install one of them (e.g. coreutils) and re-run, or download and verify manually." >&2
+  exit 1
 fi
 cd - >/dev/null
 

--- a/scripts/syllable-cli/cmd/agents.go
+++ b/scripts/syllable-cli/cmd/agents.go
@@ -195,7 +195,7 @@ func agentsGetCmd() *cobra.Command {
 		Short: "Get an agent by ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/agents/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/agents/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -342,7 +342,7 @@ func agentsDeleteCmd() *cobra.Command {
 			if err := confirmDelete(cmd, args); err != nil {
 				return err
 			}
-			data, _, err := apiClient.Delete("/api/v1/agents/" + args[0])
+			data, _, err := apiClient.Delete("/api/v1/agents/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}

--- a/scripts/syllable-cli/cmd/channels.go
+++ b/scripts/syllable-cli/cmd/channels.go
@@ -359,7 +359,7 @@ func channelsTargetsGetCmd() *cobra.Command {
 		Short: "Get a channel target",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			path := fmt.Sprintf("/api/v1/channels/%s/targets/%s", args[0], args[1])
+			path := fmt.Sprintf("/api/v1/channels/%s/targets/%s", url.PathEscape(args[0]), url.PathEscape(args[1]))
 			data, _, err := apiClient.Get(path)
 			if err != nil {
 				return err
@@ -392,7 +392,7 @@ func channelsTargetsCreateCmd() *cobra.Command {
 				return fmt.Errorf("use --file to provide target body")
 			}
 
-			path := fmt.Sprintf("/api/v1/channels/%s/targets", args[0])
+			path := fmt.Sprintf("/api/v1/channels/%s/targets", url.PathEscape(args[0]))
 			data, _, err := apiClient.Post(path, body)
 			if err != nil {
 				return err
@@ -429,7 +429,7 @@ func channelsTargetsUpdateCmd() *cobra.Command {
 				return fmt.Errorf("use --file to provide update body")
 			}
 
-			path := fmt.Sprintf("/api/v1/channels/%s/targets/%s", args[0], args[1])
+			path := fmt.Sprintf("/api/v1/channels/%s/targets/%s", url.PathEscape(args[0]), url.PathEscape(args[1]))
 			data, _, err := apiClient.Put(path, body)
 			if err != nil {
 				return err
@@ -523,7 +523,7 @@ carrier per-number registration or legal/content compliance.`,
 			}
 
 			body := map[string]interface{}{"phone": phone}
-			path := fmt.Sprintf("/api/v1/channels/twilio/%s/numbers/verify-a2p-compliance", args[0])
+			path := fmt.Sprintf("/api/v1/channels/twilio/%s/numbers/verify-a2p-compliance", url.PathEscape(args[0]))
 			data, _, err := apiClient.Post(path, body)
 			if err != nil {
 				return err
@@ -545,7 +545,7 @@ func channelsTwilioGetCmd() *cobra.Command {
 		Short: "Get a Twilio channel",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/channels/twilio/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/channels/twilio/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -631,7 +631,7 @@ func channelsTwilioNumbersListCmd() *cobra.Command {
 		Short: "List phone numbers for a Twilio channel",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/channels/twilio/" + args[0] + "/numbers")
+			data, _, err := apiClient.Get("/api/v1/channels/twilio/" + url.PathEscape(args[0]) + "/numbers")
 			if err != nil {
 				return err
 			}
@@ -663,7 +663,7 @@ func channelsTwilioNumbersAddCmd() *cobra.Command {
 				return fmt.Errorf("use --file to provide numbers body")
 			}
 
-			data, _, err := apiClient.Post("/api/v1/channels/twilio/"+args[0]+"/numbers", body)
+			data, _, err := apiClient.Post("/api/v1/channels/twilio/"+ url.PathEscape(args[0]) +"/numbers", body)
 			if err != nil {
 				return err
 			}
@@ -699,7 +699,7 @@ func channelsTwilioNumbersUpdateCmd() *cobra.Command {
 				return fmt.Errorf("use --file to provide update body")
 			}
 
-			data, _, err := apiClient.Put("/api/v1/channels/twilio/"+args[0]+"/numbers", body)
+			data, _, err := apiClient.Put("/api/v1/channels/twilio/"+ url.PathEscape(args[0]) +"/numbers", body)
 			if err != nil {
 				return err
 			}

--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -2901,6 +2901,60 @@ func TestDeleteRequiresConfirmation(t *testing.T) {
 	}
 }
 
+func TestPathAndQueryEscaping(t *testing.T) {
+	var escapedPath, dashName string
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		escapedPath = r.URL.EscapedPath()
+		dashName = r.URL.Query().Get("dashboard_name")
+		w.Write([]byte(`{}`))
+	})
+	defer server.Close()
+
+	// A slash in a path segment must be percent-encoded, not split into segments
+	// (which would route to a different endpoint) (#126).
+	cmd := agentsGetCmd()
+	cmd.SetArgs([]string{"x/y"})
+	captureStdout(func() { _ = cmd.Execute() })
+	if escapedPath != "/api/v1/agents/x%2Fy" {
+		t.Errorf("path segment not escaped: %q", escapedPath)
+	}
+
+	// A query value with a space and & must round-trip intact, not inject params.
+	cmd = dashboardsFetchInfoCmd()
+	cmd.SetArgs([]string{"--name", "Quarterly Report & KPIs"})
+	captureStdout(func() { _ = cmd.Execute() })
+	if dashName != "Quarterly Report & KPIs" {
+		t.Errorf("dashboard_name not round-tripped: %q", dashName)
+	}
+}
+
+func TestSetupMergeKeysRefusesUnresolvedPlaceholder(t *testing.T) {
+	stored := &setupConfig{Orgs: map[string]setupOrg{
+		"acme": {APIKey: "real-key", Envs: map[string]setupOrgEnv{}},
+	}}
+
+	// Unchanged org: the placeholder resolves to the stored key.
+	in := &setupConfig{Orgs: map[string]setupOrg{
+		"acme": {APIKey: setupKeyPlaceholder, Envs: map[string]setupOrgEnv{}},
+	}}
+	merged, err := setupMergeKeys(in, stored)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if merged.Orgs["acme"].APIKey != "real-key" {
+		t.Errorf("placeholder not resolved: %q", merged.Orgs["acme"].APIKey)
+	}
+
+	// Renamed org: a placeholder under a name with no stored key must be refused,
+	// not written as an empty key (#130).
+	renamed := &setupConfig{Orgs: map[string]setupOrg{
+		"acme-renamed": {APIKey: setupKeyPlaceholder, Envs: map[string]setupOrgEnv{}},
+	}}
+	if _, err := setupMergeKeys(renamed, stored); err == nil {
+		t.Error("expected a refusal when a renamed org's key can't be resolved")
+	}
+}
+
 func TestSetupGuardRequest(t *testing.T) {
 	const host = "127.0.0.1:54321"
 	const token = "sekret-token"

--- a/scripts/syllable-cli/cmd/custom_messages.go
+++ b/scripts/syllable-cli/cmd/custom_messages.go
@@ -112,7 +112,7 @@ func customMessagesGetCmd() *cobra.Command {
 		Short: "Get a custom message by ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/custom_messages/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/custom_messages/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -256,7 +256,7 @@ func customMessagesDeleteCmd() *cobra.Command {
 			if err := confirmDelete(cmd, args); err != nil {
 				return err
 			}
-			data, _, err := apiClient.Delete("/api/v1/custom_messages/" + args[0])
+			data, _, err := apiClient.Delete("/api/v1/custom_messages/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}

--- a/scripts/syllable-cli/cmd/dashboards.go
+++ b/scripts/syllable-cli/cmd/dashboards.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -228,7 +229,7 @@ func dashboardsFetchInfoCmd() *cobra.Command {
 				return fmt.Errorf("--name is required (e.g. session_events, session_summary)")
 			}
 
-			path := fmt.Sprintf("/api/v1/dashboards/fetch_info?dashboard_name=%s", name)
+			path := fmt.Sprintf("/api/v1/dashboards/fetch_info?dashboard_name=%s", url.QueryEscape(name))
 			data, _, err := apiClient.Post(path, map[string]interface{}{})
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/data_sources.go
+++ b/scripts/syllable-cli/cmd/data_sources.go
@@ -113,7 +113,7 @@ func dataSourcesGetCmd() *cobra.Command {
 		Short: "Get a data source by ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/data_sources/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/data_sources/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -240,7 +240,7 @@ func dataSourcesDeleteCmd() *cobra.Command {
 			if err := confirmDelete(cmd, args); err != nil {
 				return err
 			}
-			data, _, err := apiClient.Delete("/api/v1/data_sources/" + args[0])
+			data, _, err := apiClient.Delete("/api/v1/data_sources/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}

--- a/scripts/syllable-cli/cmd/directory.go
+++ b/scripts/syllable-cli/cmd/directory.go
@@ -127,7 +127,7 @@ func directoryGetCmd() *cobra.Command {
 		Short: "Get a directory member by ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/directory_members/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/directory_members/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -262,7 +262,7 @@ func directoryDeleteCmd() *cobra.Command {
 			if err := confirmDelete(cmd, args); err != nil {
 				return err
 			}
-			data, _, err := apiClient.Delete("/api/v1/directory_members/" + args[0] + "?comment=deleted+via+cli")
+			data, _, err := apiClient.Delete("/api/v1/directory_members/" + url.PathEscape(args[0]) + "?comment=deleted+via+cli")
 			if err != nil {
 				return err
 			}
@@ -332,7 +332,7 @@ func directoryHistoryCmd() *cobra.Command {
 		Short: "Show version history for a directory member",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			path := fmt.Sprintf("/api/v1/directory_members/%s/history?page=%d&limit=%d", args[0], page, limit)
+			path := fmt.Sprintf("/api/v1/directory_members/%s/history?page=%d&limit=%d", url.PathEscape(args[0]), page, limit)
 			if orderByDirection != "" {
 				path += "&order_by_direction=" + url.QueryEscape(orderByDirection)
 			}
@@ -367,7 +367,7 @@ func directoryRestoreCmd() *cobra.Command {
 			if comments != "" {
 				body["comments"] = comments
 			}
-			data, _, err := apiClient.Put("/api/v1/directory_members/"+args[0]+"/restore", body)
+			data, _, err := apiClient.Put("/api/v1/directory_members/"+ url.PathEscape(args[0]) +"/restore", body)
 			if err != nil {
 				return err
 			}

--- a/scripts/syllable-cli/cmd/incidents.go
+++ b/scripts/syllable-cli/cmd/incidents.go
@@ -117,7 +117,7 @@ func incidentsGetCmd() *cobra.Command {
 		Short: "Get an incident by ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/incidents/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/incidents/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -206,7 +206,7 @@ func incidentsDeleteCmd() *cobra.Command {
 			if err := confirmDelete(cmd, args); err != nil {
 				return err
 			}
-			data, _, err := apiClient.Delete("/api/v1/incidents/" + args[0])
+			data, _, err := apiClient.Delete("/api/v1/incidents/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}

--- a/scripts/syllable-cli/cmd/insights.go
+++ b/scripts/syllable-cli/cmd/insights.go
@@ -212,7 +212,7 @@ func insightsWorkflowsGetCmd() *cobra.Command {
 		Short: "Get an insight workflow by ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/insights/workflows/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/insights/workflows/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -340,7 +340,7 @@ func insightsWorkflowsDeleteCmd() *cobra.Command {
 			if err := confirmDelete(cmd, args); err != nil {
 				return err
 			}
-			data, _, err := apiClient.Delete("/api/v1/insights/workflows/" + args[0])
+			data, _, err := apiClient.Delete("/api/v1/insights/workflows/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -361,7 +361,7 @@ func insightsWorkflowsActivateCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Fetch the current workflow to get the exact estimate the API requires.
-			wfData, _, err := apiClient.Get("/api/v1/insights/workflows/" + args[0])
+			wfData, _, err := apiClient.Get("/api/v1/insights/workflows/" + url.PathEscape(args[0]))
 			if err != nil {
 				return fmt.Errorf("fetching workflow: %w", err)
 			}
@@ -377,7 +377,7 @@ func insightsWorkflowsActivateCmd() *cobra.Command {
 				"estimate":        wf.Estimate,
 			}
 
-			path := fmt.Sprintf("/api/v1/insights/workflows/%s/activate", args[0])
+			path := fmt.Sprintf("/api/v1/insights/workflows/%s/activate", url.PathEscape(args[0]))
 			data, _, err := apiClient.Put(path, body)
 			if err != nil {
 				return err
@@ -395,7 +395,7 @@ func insightsWorkflowsInactivateCmd() *cobra.Command {
 		Short: "Inactivate an insight workflow",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			path := fmt.Sprintf("/api/v1/insights/workflows/%s/inactivate", args[0])
+			path := fmt.Sprintf("/api/v1/insights/workflows/%s/inactivate", url.PathEscape(args[0]))
 			data, _, err := apiClient.Put(path, map[string]interface{}{})
 			if err != nil {
 				return err
@@ -489,7 +489,7 @@ func insightsFoldersGetCmd() *cobra.Command {
 		Short: "Get an insight folder by ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/insights/folders/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/insights/folders/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -608,7 +608,7 @@ func insightsFoldersDeleteCmd() *cobra.Command {
 			if err := confirmDelete(cmd, args); err != nil {
 				return err
 			}
-			data, _, err := apiClient.Delete("/api/v1/insights/folders/" + args[0])
+			data, _, err := apiClient.Delete("/api/v1/insights/folders/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -628,7 +628,7 @@ func insightsFoldersFilesCmd() *cobra.Command {
 		Short: "List files in an insight folder",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/insights/folders/" + args[0] + "/files")
+			data, _, err := apiClient.Get("/api/v1/insights/folders/" + url.PathEscape(args[0]) + "/files")
 			if err != nil {
 				return err
 			}
@@ -680,7 +680,7 @@ func insightsFoldersUploadFileCmd() *cobra.Command {
 				params.Set("metadata", metadata)
 			}
 
-			path := fmt.Sprintf("/api/v1/insights/folders/%s/upload-file?%s", args[0], params.Encode())
+			path := fmt.Sprintf("/api/v1/insights/folders/%s/upload-file?%s", url.PathEscape(args[0]), params.Encode())
 			data, _, err := apiClient.PostMultipart(path, "file", filePath)
 			if err != nil {
 				return err
@@ -755,7 +755,7 @@ func insightsToolConfigsGetCmd() *cobra.Command {
 		Short: "Get an insight tool configuration",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/insights/tool-configurations/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/insights/tool-configurations/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -845,7 +845,7 @@ func insightsToolConfigsDeleteCmd() *cobra.Command {
 			if err := confirmDelete(cmd, args); err != nil {
 				return err
 			}
-			data, _, err := apiClient.Delete("/api/v1/insights/tool-configurations/" + args[0])
+			data, _, err := apiClient.Delete("/api/v1/insights/tool-configurations/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -935,7 +935,7 @@ func insightsFoldersMoveFilesCmd() *cobra.Command {
 				return fmt.Errorf("parsing JSON file: %w", err)
 			}
 
-			path := fmt.Sprintf("/api/v1/insights/folders/%s/move-files", args[0])
+			path := fmt.Sprintf("/api/v1/insights/folders/%s/move-files", url.PathEscape(args[0]))
 			data, _, err := apiClient.Post(path, body)
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/language_groups.go
+++ b/scripts/syllable-cli/cmd/language_groups.go
@@ -110,7 +110,7 @@ func languageGroupsGetCmd() *cobra.Command {
 		Short: "Get a language group by ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/language_groups/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/language_groups/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -239,7 +239,7 @@ func languageGroupsDeleteCmd() *cobra.Command {
 			if err := confirmDelete(cmd, args); err != nil {
 				return err
 			}
-			data, _, err := apiClient.Delete("/api/v1/language_groups/" + args[0])
+			data, _, err := apiClient.Delete("/api/v1/language_groups/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}

--- a/scripts/syllable-cli/cmd/organizations.go
+++ b/scripts/syllable-cli/cmd/organizations.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -209,7 +210,7 @@ func organizationsSipIPRangesUpdateCmd() *cobra.Command {
 				body = m
 			}
 
-			path := fmt.Sprintf("/api/v1/organizations/sip_ip_ranges/%s", args[0])
+			path := fmt.Sprintf("/api/v1/organizations/sip_ip_ranges/%s", url.PathEscape(args[0]))
 			data, _, err := apiClient.Put(path, body)
 			if err != nil {
 				return err
@@ -236,7 +237,7 @@ func organizationsSipIPRangesDeleteCmd() *cobra.Command {
 			if err := confirmDelete(cmd, args); err != nil {
 				return err
 			}
-			path := fmt.Sprintf("/api/v1/organizations/sip_ip_ranges/%s", args[0])
+			path := fmt.Sprintf("/api/v1/organizations/sip_ip_ranges/%s", url.PathEscape(args[0]))
 			data, _, err := apiClient.Delete(path)
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/outbound.go
+++ b/scripts/syllable-cli/cmd/outbound.go
@@ -143,7 +143,7 @@ func outboundBatchesGetCmd() *cobra.Command {
 		Short: "Get an outbound batch by ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/outbound/batches/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/outbound/batches/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -311,7 +311,7 @@ func outboundBatchesResultsCmd() *cobra.Command {
 		Short: "Get results for an outbound batch",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/outbound/batches/" + args[0] + "/results")
+			data, _, err := apiClient.Get("/api/v1/outbound/batches/" + url.PathEscape(args[0]) + "/results")
 			if err != nil {
 				return err
 			}
@@ -343,7 +343,7 @@ func outboundBatchesRequestsCmd() *cobra.Command {
 				return fmt.Errorf("use --file to provide requests body")
 			}
 
-			data, _, err := apiClient.Post("/api/v1/outbound/batches/"+args[0]+"/requests", body)
+			data, _, err := apiClient.Post("/api/v1/outbound/batches/"+ url.PathEscape(args[0]) +"/requests", body)
 			if err != nil {
 				return err
 			}
@@ -379,7 +379,7 @@ func outboundBatchesRemoveRequestsCmd() *cobra.Command {
 				return fmt.Errorf("use --file to provide requests body")
 			}
 
-			data, _, err := apiClient.Post("/api/v1/outbound/batches/"+args[0]+"/remove-requests", body)
+			data, _, err := apiClient.Post("/api/v1/outbound/batches/"+ url.PathEscape(args[0]) +"/remove-requests", body)
 			if err != nil {
 				return err
 			}
@@ -404,7 +404,7 @@ func outboundBatchesUploadCmd() *cobra.Command {
 			if file == "" {
 				return fmt.Errorf("required flag: --file")
 			}
-			path := fmt.Sprintf("/api/v1/outbound/batches/%s/upload_batch", args[0])
+			path := fmt.Sprintf("/api/v1/outbound/batches/%s/upload_batch", url.PathEscape(args[0]))
 			data, _, err := apiClient.PostMultipart(path, "file", file)
 			if err != nil {
 				return err
@@ -506,7 +506,7 @@ func outboundCampaignsGetCmd() *cobra.Command {
 		Short: "Get an outbound campaign by ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/outbound/campaigns/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/outbound/campaigns/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -662,7 +662,7 @@ func outboundCampaignsDeleteCmd() *cobra.Command {
 			if err := confirmDelete(cmd, args); err != nil {
 				return err
 			}
-			data, _, err := apiClient.Delete("/api/v1/outbound/campaigns/" + args[0])
+			data, _, err := apiClient.Delete("/api/v1/outbound/campaigns/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}

--- a/scripts/syllable-cli/cmd/prompts.go
+++ b/scripts/syllable-cli/cmd/prompts.go
@@ -117,7 +117,7 @@ func promptsGetCmd() *cobra.Command {
 		Short: "Get a prompt by ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/prompts/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/prompts/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -255,7 +255,7 @@ func promptsDeleteCmd() *cobra.Command {
 			if err := confirmDelete(cmd, args); err != nil {
 				return err
 			}
-			data, _, err := apiClient.Delete("/api/v1/prompts/" + args[0])
+			data, _, err := apiClient.Delete("/api/v1/prompts/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -275,7 +275,7 @@ func promptsHistoryCmd() *cobra.Command {
 		Short: "Get version history for a prompt",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/prompts/" + args[0] + "/history")
+			data, _, err := apiClient.Get("/api/v1/prompts/" + url.PathEscape(args[0]) + "/history")
 			if err != nil {
 				return err
 			}

--- a/scripts/syllable-cli/cmd/roles.go
+++ b/scripts/syllable-cli/cmd/roles.go
@@ -113,7 +113,7 @@ func rolesGetCmd() *cobra.Command {
 		Short: "Get a role by ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/roles/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/roles/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -235,7 +235,7 @@ func rolesDeleteCmd() *cobra.Command {
 			if err := confirmDelete(cmd, args); err != nil {
 				return err
 			}
-			data, _, err := apiClient.Delete("/api/v1/roles/" + args[0])
+			data, _, err := apiClient.Delete("/api/v1/roles/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}

--- a/scripts/syllable-cli/cmd/root.go
+++ b/scripts/syllable-cli/cmd/root.go
@@ -313,8 +313,16 @@ func initConfig() {
 	// Defaults
 	viper.SetDefault("output", "table")
 
-	// Read config file (ignore errors if not found)
-	viper.ReadInConfig()
+	// Read config file. A missing file is expected (env-var auth or first run),
+	// but any other error — most importantly malformed YAML — is surfaced so the
+	// user isn't misdirected to "not configured" when the real problem is a
+	// broken config file (#133).
+	if err := viper.ReadInConfig(); err != nil {
+		var notFound viper.ConfigFileNotFoundError
+		if !errors.As(err, &notFound) && !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "warning: could not read config %s: %v\n", viper.ConfigFileUsed(), err)
+		}
+	}
 }
 
 func initClient() error {

--- a/scripts/syllable-cli/cmd/services.go
+++ b/scripts/syllable-cli/cmd/services.go
@@ -113,7 +113,7 @@ func servicesGetCmd() *cobra.Command {
 		Short: "Get a service by ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/services/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/services/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -236,7 +236,7 @@ func servicesDeleteCmd() *cobra.Command {
 			if err := confirmDelete(cmd, args); err != nil {
 				return err
 			}
-			data, _, err := apiClient.Delete("/api/v1/services/" + args[0])
+			data, _, err := apiClient.Delete("/api/v1/services/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}

--- a/scripts/syllable-cli/cmd/session_debug.go
+++ b/scripts/syllable-cli/cmd/session_debug.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -35,7 +36,7 @@ func sessionDebugBySessionIDCmd() *cobra.Command {
 		Short: "Get debug info by session ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/session_debug/session_id/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/session_debug/session_id/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -51,7 +52,7 @@ func sessionDebugBySIDCmd() *cobra.Command {
 		Short: "Get debug info by channel manager SID",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			path := fmt.Sprintf("/api/v1/session_debug/sid/%s/%s", args[0], args[1])
+			path := fmt.Sprintf("/api/v1/session_debug/sid/%s/%s", url.PathEscape(args[0]), url.PathEscape(args[1]))
 			data, _, err := apiClient.Get(path)
 			if err != nil {
 				return err
@@ -68,7 +69,7 @@ func sessionDebugToolResultCmd() *cobra.Command {
 		Short: "Get tool result for a session",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			path := fmt.Sprintf("/api/v1/session_debug/tool_result/%s/%s", args[0], args[1])
+			path := fmt.Sprintf("/api/v1/session_debug/tool_result/%s/%s", url.PathEscape(args[0]), url.PathEscape(args[1]))
 			data, _, err := apiClient.Get(path)
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/session_labels.go
+++ b/scripts/syllable-cli/cmd/session_labels.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
@@ -83,7 +84,7 @@ func sessionLabelsGetCmd() *cobra.Command {
 		Short: "Get a session label by ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/session_labels/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/session_labels/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}

--- a/scripts/syllable-cli/cmd/sessions.go
+++ b/scripts/syllable-cli/cmd/sessions.go
@@ -181,7 +181,7 @@ func sessionsGetCmd() *cobra.Command {
 		Short: "Get a session by ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/sessions/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/sessions/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -248,7 +248,7 @@ func sessionsTranscriptCmd() *cobra.Command {
 		Short: "Get transcript for a session",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/sessions/transcript/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/sessions/transcript/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -289,7 +289,7 @@ func sessionsSummaryCmd() *cobra.Command {
 		Short: "Get summary for a session",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/sessions/full-summary/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/sessions/full-summary/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -324,7 +324,7 @@ func sessionsLatencyCmd() *cobra.Command {
 		Short: "Get latency info for a session",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/sessions/latency/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/sessions/latency/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}

--- a/scripts/syllable-cli/cmd/setup.go
+++ b/scripts/syllable-cli/cmd/setup.go
@@ -118,7 +118,13 @@ func setupCmd() *cobra.Command {
 					return
 				}
 
-				merged := setupMergeKeys(&incoming, real)
+				merged, err := setupMergeKeys(&incoming, real)
+				if err != nil {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(400)
+					json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+					return
+				}
 
 				if err := setupWriteConfig(cfgPath, merged); err != nil {
 					w.Header().Set("Content-Type", "application/json")
@@ -153,11 +159,26 @@ func setupCmd() *cobra.Command {
 				}
 			}()
 
+			// Don't let the loopback server linger unattended if the user closes
+			// the tab or walks away — bound its lifetime (#127).
+			idleTimedOut := false
+			idleTimer := time.AfterFunc(15*time.Minute, func() {
+				exitOnce.Do(func() {
+					idleTimedOut = true
+					close(done)
+				})
+			})
+			defer idleTimer.Stop()
+
 			<-done
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
 			srv.Shutdown(ctx)
-			fmt.Printf("\nConfig saved to %s\n", cfgPath)
+			if idleTimedOut {
+				fmt.Fprintln(os.Stderr, "\nSetup closed after 15 minutes with no save.")
+			} else {
+				fmt.Printf("\nConfig saved to %s\n", cfgPath)
+			}
 			return nil
 		},
 	}
@@ -268,25 +289,27 @@ func setupMaskKey(k string) string {
 	return setupKeyPlaceholder
 }
 
-func setupMergeKeys(incoming *setupConfig, stored *setupConfig) *setupConfig {
+// setupMergeKeys substitutes the real stored key for each "__existing__"
+// placeholder the browser holds. If a placeholder can't be resolved — which is
+// exactly what happens when an org/env was renamed — it returns an error rather
+// than writing an empty key, so the real key is never silently wiped and the
+// on-disk config is left untouched (#130).
+func setupMergeKeys(incoming *setupConfig, stored *setupConfig) (*setupConfig, error) {
 	for name, org := range incoming.Orgs {
 		if org.APIKey == setupKeyPlaceholder {
-			if s, ok := stored.Orgs[name]; ok {
+			if s, ok := stored.Orgs[name]; ok && s.APIKey != "" {
 				org.APIKey = s.APIKey
 			} else {
-				org.APIKey = ""
+				return nil, fmt.Errorf("the API key for org %q couldn't be carried over (it looks renamed) — re-enter the key before saving", name)
 			}
 		}
 		for env, e := range org.Envs {
 			if e.APIKey == setupKeyPlaceholder {
-				if s, ok := stored.Orgs[name]; ok {
-					if se, ok := s.Envs[env]; ok {
-						e.APIKey = se.APIKey
-					} else {
-						e.APIKey = ""
-					}
+				s, ok := stored.Orgs[name]
+				if se, ok2 := s.Envs[env]; ok && ok2 && se.APIKey != "" {
+					e.APIKey = se.APIKey
 				} else {
-					e.APIKey = ""
+					return nil, fmt.Errorf("the API key for org %q environment %q couldn't be carried over (it looks renamed) — re-enter the key before saving", name, env)
 				}
 				org.Envs[env] = e
 			}
@@ -299,7 +322,7 @@ func setupMergeKeys(incoming *setupConfig, stored *setupConfig) *setupConfig {
 	if len(incoming.Environments) == 0 {
 		incoming.Environments = nil
 	}
-	return incoming
+	return incoming, nil
 }
 
 func setupOpenBrowser(url string) {

--- a/scripts/syllable-cli/cmd/takeouts.go
+++ b/scripts/syllable-cli/cmd/takeouts.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -75,7 +76,7 @@ func takeoutsGetCmd() *cobra.Command {
 		Short: "Get a takeout job status",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/takeouts/get/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/takeouts/get/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -91,7 +92,7 @@ func takeoutsDownloadCmd() *cobra.Command {
 		Short: "Download a takeout file",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			path := fmt.Sprintf("/api/v1/takeouts/get/%s/file/%s", args[0], args[1])
+			path := fmt.Sprintf("/api/v1/takeouts/get/%s/file/%s", url.PathEscape(args[0]), url.PathEscape(args[1]))
 			data, _, err := apiClient.Get(path)
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/tools.go
+++ b/scripts/syllable-cli/cmd/tools.go
@@ -54,7 +54,7 @@ func toolsHistoryCmd() *cobra.Command {
 		Short: "List version history for a tool",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			path := fmt.Sprintf("/api/v1/tools/%s/history?page=%d&limit=%d", args[0], page, limit)
+			path := fmt.Sprintf("/api/v1/tools/%s/history?page=%d&limit=%d", url.PathEscape(args[0]), page, limit)
 			if orderByDirection != "" {
 				path += "&order_by_direction=" + orderByDirection
 			}
@@ -229,7 +229,7 @@ func toolsGetCmd() *cobra.Command {
 		Short: "Get a tool by name (numeric IDs are resolved via the list endpoint)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/tools/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/tools/" + url.PathEscape(args[0]))
 			if err != nil {
 				// The get endpoint is name-keyed, but `tools list` leads with
 				// the ID column — resolve an all-digits arg by ID and retry (#69).
@@ -237,7 +237,7 @@ func toolsGetCmd() *cobra.Command {
 				if !ok {
 					return err
 				}
-				if data, _, err = apiClient.Get("/api/v1/tools/" + name); err != nil {
+				if data, _, err = apiClient.Get("/api/v1/tools/" + url.PathEscape(name)); err != nil {
 					return err
 				}
 			}
@@ -374,7 +374,7 @@ func toolsDeleteCmd() *cobra.Command {
 			if err := confirmDelete(cmd, args); err != nil {
 				return err
 			}
-			data, _, err := apiClient.Delete("/api/v1/tools/" + args[0])
+			data, _, err := apiClient.Delete("/api/v1/tools/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}

--- a/scripts/syllable-cli/cmd/users.go
+++ b/scripts/syllable-cli/cmd/users.go
@@ -166,7 +166,7 @@ func usersGetCmd() *cobra.Command {
 		Short: "Get a user by email",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/users/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/users/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -354,7 +354,7 @@ func usersMeCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			email := viper.GetString("email")
 			if email != "" {
-				data, _, err := apiClient.Get("/api/v1/users/" + email)
+				data, _, err := apiClient.Get("/api/v1/users/" + url.PathEscape(email))
 				if err != nil {
 					return err
 				}
@@ -419,7 +419,7 @@ func usersSendEmailCmd() *cobra.Command {
 		Short: "Send an email to a user",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Post("/api/v1/users/"+args[0]+"/send_email", map[string]interface{}{})
+			data, _, err := apiClient.Post("/api/v1/users/"+ url.PathEscape(args[0]) +"/send_email", map[string]interface{}{})
 			if err != nil {
 				return err
 			}

--- a/scripts/syllable-cli/cmd/voice_groups.go
+++ b/scripts/syllable-cli/cmd/voice_groups.go
@@ -152,7 +152,7 @@ func voiceGroupsGetCmd() *cobra.Command {
 		Short: "Get a voice group by ID",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/voice_groups/" + args[0])
+			data, _, err := apiClient.Get("/api/v1/voice_groups/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}
@@ -274,7 +274,7 @@ func voiceGroupsDeleteCmd() *cobra.Command {
 			if err := confirmDelete(cmd, args); err != nil {
 				return err
 			}
-			data, _, err := apiClient.Delete("/api/v1/voice_groups/" + args[0])
+			data, _, err := apiClient.Delete("/api/v1/voice_groups/" + url.PathEscape(args[0]))
 			if err != nil {
 				return err
 			}

--- a/scripts/syllable-cli/internal/client/client.go
+++ b/scripts/syllable-cli/internal/client/client.go
@@ -208,7 +208,9 @@ func maskKey(key string) string {
 	if len(key) <= 8 {
 		return "****"
 	}
-	return key[:4] + strings.Repeat("*", len(key)-8) + key[len(key)-4:]
+	// Reveal only a short prefix for recognizability — not the suffix, and not
+	// the exact length (a fixed-width mask), so --debug output is safer to share (#127).
+	return key[:4] + "****"
 }
 
 // Get performs a GET request.


### PR DESCRIPTION
Third code-review batch — finishing the security epic and several IO-correctness fixes. **4 issues**, tested, `go test -race` green.

- **#126** — every interpolated path segment is now `url.PathEscape`'d, and the `dashboards fetch-info` query value `url.QueryEscape`'d. A value containing `/`, `?`, `#`, or `&` can no longer reroute a request to a different endpoint or inject query params. New `TestPathAndQueryEscaping` proves a `/` in a segment is percent-encoded and a `&`/space in a query value round-trips.
- **#127** — three hardening items: setup's loopback server now self-closes after 15 minutes so it can't linger unattended; `maskKey` reveals only a short prefix (no suffix, no exact length) in `--debug`; `install.sh` aborts instead of installing an unverified binary when neither `sha256sum` nor `shasum` exists.
- **#130** — renaming an org/env in setup no longer silently wipes its API key. `setupMergeKeys` now refuses an unresolvable `__existing__` placeholder with a clear "re-enter the key" error and leaves the on-disk config untouched, instead of writing an empty key. New test.
- **#133** — a malformed `~/.syllable/config.yaml` now surfaces a parse warning with the file path, instead of misdirecting the user to "not configured".

Closes #126, #127, #130, #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
