### PR TITLE
Code review batch 5: Go 1.24 toolchain, repo-wide gofmt, CI format gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,16 @@ jobs:
           go-version-file: scripts/syllable-cli/go.mod
           cache-dependency-path: scripts/syllable-cli/go.sum
 
+      - name: Format and vet
+        working-directory: scripts/syllable-cli
+        run: |
+          if [ -n "$(gofmt -l .)" ]; then
+            echo "::error::gofmt drift — run 'gofmt -w .' in scripts/syllable-cli"
+            gofmt -l .
+            exit 1
+          fi
+          go vet ./...
+
       - name: Run unit tests
         working-directory: scripts/syllable-cli
         # The integration suite is gated behind the `integration` build tag, so

--- a/scripts/syllable-cli/cmd/agents.go
+++ b/scripts/syllable-cli/cmd/agents.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func agentsCmd() *cobra.Command {
@@ -150,11 +150,11 @@ func agentsListCmd() *cobra.Command {
 			var result struct {
 				Items []struct {
 					ID          json.Number `json:"id"`
-					Name        string `json:"name"`
-					Description string `json:"description"`
-					Type        string `json:"type"`
-					Label       string `json:"label"`
-					UpdatedAt   string `json:"updated_at"`
+					Name        string      `json:"name"`
+					Description string      `json:"description"`
+					Type        string      `json:"type"`
+					Label       string      `json:"label"`
+					UpdatedAt   string      `json:"updated_at"`
 				} `json:"items"`
 				TotalCount int `json:"total_count"`
 			}
@@ -212,9 +212,9 @@ func agentsGetCmd() *cobra.Command {
 				Type        string      `json:"type"`
 				Label       string      `json:"label"`
 				PromptID    json.Number `json:"prompt_id"`
-				Timezone    string `json:"timezone"`
-				UpdatedAt   string `json:"updated_at"`
-				LastUpdBy   string `json:"last_updated_by"`
+				Timezone    string      `json:"timezone"`
+				UpdatedAt   string      `json:"updated_at"`
+				LastUpdBy   string      `json:"last_updated_by"`
 			}
 			if err := json.Unmarshal(data, &a); err != nil {
 				output.PrintJSON(data)

--- a/scripts/syllable-cli/cmd/channels.go
+++ b/scripts/syllable-cli/cmd/channels.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func channelsCmd() *cobra.Command {
@@ -318,10 +318,10 @@ func channelsTargetsListCmd() *cobra.Command {
 					ID          json.Number `json:"id"`
 					AgentID     json.Number `json:"agent_id"`
 					ChannelID   json.Number `json:"channel_id"`
-					ChannelName string `json:"channel_name"`
-					Target      string `json:"target"`
-					TargetMode  string `json:"target_mode"`
-					IsTest      bool   `json:"is_test"`
+					ChannelName string      `json:"channel_name"`
+					Target      string      `json:"target"`
+					TargetMode  string      `json:"target_mode"`
+					IsTest      bool        `json:"is_test"`
 				} `json:"items"`
 				TotalCount int `json:"total_count"`
 			}
@@ -663,7 +663,7 @@ func channelsTwilioNumbersAddCmd() *cobra.Command {
 				return fmt.Errorf("use --file to provide numbers body")
 			}
 
-			data, _, err := apiClient.Post("/api/v1/channels/twilio/"+ url.PathEscape(args[0]) +"/numbers", body)
+			data, _, err := apiClient.Post("/api/v1/channels/twilio/"+url.PathEscape(args[0])+"/numbers", body)
 			if err != nil {
 				return err
 			}
@@ -699,7 +699,7 @@ func channelsTwilioNumbersUpdateCmd() *cobra.Command {
 				return fmt.Errorf("use --file to provide update body")
 			}
 
-			data, _, err := apiClient.Put("/api/v1/channels/twilio/"+ url.PathEscape(args[0]) +"/numbers", body)
+			data, _, err := apiClient.Put("/api/v1/channels/twilio/"+url.PathEscape(args[0])+"/numbers", body)
 			if err != nil {
 				return err
 			}

--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/asksyllable/syllable-cli/internal/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/asksyllable/syllable-cli/internal/client"
 )
 
 // setupTestServer creates a test HTTP server and configures the global apiClient.

--- a/scripts/syllable-cli/cmd/conversation_config.go
+++ b/scripts/syllable-cli/cmd/conversation_config.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func conversationConfigCmd() *cobra.Command {

--- a/scripts/syllable-cli/cmd/conversations.go
+++ b/scripts/syllable-cli/cmd/conversations.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func conversationsCmd() *cobra.Command {

--- a/scripts/syllable-cli/cmd/custom_messages.go
+++ b/scripts/syllable-cli/cmd/custom_messages.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func customMessagesCmd() *cobra.Command {
@@ -68,11 +68,11 @@ func customMessagesListCmd() *cobra.Command {
 			var result struct {
 				Items []struct {
 					ID         json.Number `json:"id"`
-					Name       string `json:"name"`
-					Type       string `json:"type"`
-					AgentCount int    `json:"agent_count"`
-					UpdatedAt  string `json:"updated_at"`
-					LastUpdBy  string `json:"last_updated_by"`
+					Name       string      `json:"name"`
+					Type       string      `json:"type"`
+					AgentCount int         `json:"agent_count"`
+					UpdatedAt  string      `json:"updated_at"`
+					LastUpdBy  string      `json:"last_updated_by"`
 				} `json:"items"`
 				TotalCount int `json:"total_count"`
 			}

--- a/scripts/syllable-cli/cmd/dashboards.go
+++ b/scripts/syllable-cli/cmd/dashboards.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func dashboardsCmd() *cobra.Command {

--- a/scripts/syllable-cli/cmd/data_sources.go
+++ b/scripts/syllable-cli/cmd/data_sources.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func dataSourcesCmd() *cobra.Command {

--- a/scripts/syllable-cli/cmd/directory.go
+++ b/scripts/syllable-cli/cmd/directory.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func directoryCmd() *cobra.Command {
@@ -90,10 +90,10 @@ func directoryListCmd() *cobra.Command {
 			var result struct {
 				Items []struct {
 					ID        json.Number `json:"id"`
-					Name      string `json:"name"`
-					Type      string `json:"type"`
-					CreatedAt string `json:"created_at"`
-					UpdatedAt string `json:"updated_at"`
+					Name      string      `json:"name"`
+					Type      string      `json:"type"`
+					CreatedAt string      `json:"created_at"`
+					UpdatedAt string      `json:"updated_at"`
 				} `json:"items"`
 				TotalCount int `json:"total_count"`
 			}
@@ -139,13 +139,13 @@ func directoryGetCmd() *cobra.Command {
 
 			var m struct {
 				ID        json.Number `json:"id"`
-				Name      string `json:"name"`
-				Type      string `json:"type"`
-				Comments  string `json:"comments"`
-				CreatedBy string `json:"created_by"`
-				CreatedAt string `json:"created_at"`
-				UpdatedAt string `json:"updated_at"`
-				LastUpdBy string `json:"last_updated_by"`
+				Name      string      `json:"name"`
+				Type      string      `json:"type"`
+				Comments  string      `json:"comments"`
+				CreatedBy string      `json:"created_by"`
+				CreatedAt string      `json:"created_at"`
+				UpdatedAt string      `json:"updated_at"`
+				LastUpdBy string      `json:"last_updated_by"`
 			}
 			if err := json.Unmarshal(data, &m); err != nil {
 				output.PrintJSON(data)
@@ -367,7 +367,7 @@ func directoryRestoreCmd() *cobra.Command {
 			if comments != "" {
 				body["comments"] = comments
 			}
-			data, _, err := apiClient.Put("/api/v1/directory_members/"+ url.PathEscape(args[0]) +"/restore", body)
+			data, _, err := apiClient.Put("/api/v1/directory_members/"+url.PathEscape(args[0])+"/restore", body)
 			if err != nil {
 				return err
 			}

--- a/scripts/syllable-cli/cmd/envs.go
+++ b/scripts/syllable-cli/cmd/envs.go
@@ -63,7 +63,6 @@ func envsCmd() *cobra.Command {
 			fmt.Printf("Default org: %s\n", defaultOrg)
 			fmt.Printf("Default env: %s\n\n", defaultEnv)
 
-
 			sortedEnvs := make([]string, 0, len(envSet))
 			for e := range envSet {
 				sortedEnvs = append(sortedEnvs, e)

--- a/scripts/syllable-cli/cmd/events.go
+++ b/scripts/syllable-cli/cmd/events.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func eventsCmd() *cobra.Command {

--- a/scripts/syllable-cli/cmd/incidents.go
+++ b/scripts/syllable-cli/cmd/incidents.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func incidentsCmd() *cobra.Command {
@@ -71,12 +71,12 @@ func incidentsListCmd() *cobra.Command {
 
 			var result struct {
 				Items []struct {
-					ID              json.Number `json:"id"`
-					Description     string      `json:"description"`
-					ImpactCategory  string      `json:"impact_category"`
-					SessionsImpacted int        `json:"sessions_impacted"`
-					StartDatetime   string      `json:"start_datetime"`
-					CreatedAt       string      `json:"created_at"`
+					ID               json.Number `json:"id"`
+					Description      string      `json:"description"`
+					ImpactCategory   string      `json:"impact_category"`
+					SessionsImpacted int         `json:"sessions_impacted"`
+					StartDatetime    string      `json:"start_datetime"`
+					CreatedAt        string      `json:"created_at"`
 				} `json:"items"`
 				TotalCount int `json:"total_count"`
 			}

--- a/scripts/syllable-cli/cmd/insights.go
+++ b/scripts/syllable-cli/cmd/insights.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func insightsCmd() *cobra.Command {
@@ -177,8 +177,8 @@ func insightsWorkflowsListCmd() *cobra.Command {
 					Description string      `json:"description"`
 					Source      string      `json:"source"`
 					Status      string      `json:"status"`
-					CreatedAt   string `json:"created_at"`
-					UpdatedAt   string `json:"updated_at"`
+					CreatedAt   string      `json:"created_at"`
+					UpdatedAt   string      `json:"updated_at"`
 				} `json:"items"`
 				TotalCount int `json:"total_count"`
 			}
@@ -224,14 +224,14 @@ func insightsWorkflowsGetCmd() *cobra.Command {
 
 			var w struct {
 				ID          json.Number `json:"id"`
-				Name        string `json:"name"`
-				Description string `json:"description"`
-				Source      string `json:"source"`
-				Status      string `json:"status"`
-				FailedCount *int   `json:"failed_count"`
-				CreatedAt   string `json:"created_at"`
-				UpdatedAt   string `json:"updated_at"`
-				LastUpdBy   string `json:"last_updated_by"`
+				Name        string      `json:"name"`
+				Description string      `json:"description"`
+				Source      string      `json:"source"`
+				Status      string      `json:"status"`
+				FailedCount *int        `json:"failed_count"`
+				CreatedAt   string      `json:"created_at"`
+				UpdatedAt   string      `json:"updated_at"`
+				LastUpdBy   string      `json:"last_updated_by"`
 			}
 			if err := json.Unmarshal(data, &w); err != nil {
 				output.PrintJSON(data)
@@ -455,8 +455,8 @@ func insightsFoldersListCmd() *cobra.Command {
 					ID        json.Number `json:"id"`
 					Name      string      `json:"name"`
 					Label     string      `json:"label"`
-					CreatedAt string `json:"created_at"`
-					UpdatedAt string `json:"updated_at"`
+					CreatedAt string      `json:"created_at"`
+					UpdatedAt string      `json:"updated_at"`
 				} `json:"items"`
 				TotalCount int `json:"total_count"`
 			}
@@ -501,12 +501,12 @@ func insightsFoldersGetCmd() *cobra.Command {
 
 			var f struct {
 				ID          json.Number `json:"id"`
-				Name        string `json:"name"`
-				Label       string `json:"label"`
-				Description string `json:"description"`
-				CreatedAt   string `json:"created_at"`
-				UpdatedAt   string `json:"updated_at"`
-				LastUpdBy   string `json:"last_updated_by"`
+				Name        string      `json:"name"`
+				Label       string      `json:"label"`
+				Description string      `json:"description"`
+				CreatedAt   string      `json:"created_at"`
+				UpdatedAt   string      `json:"updated_at"`
+				LastUpdBy   string      `json:"last_updated_by"`
 			}
 			if err := json.Unmarshal(data, &f); err != nil {
 				output.PrintJSON(data)

--- a/scripts/syllable-cli/cmd/language_groups.go
+++ b/scripts/syllable-cli/cmd/language_groups.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func languageGroupsCmd() *cobra.Command {
@@ -68,10 +68,10 @@ func languageGroupsListCmd() *cobra.Command {
 			var result struct {
 				Items []struct {
 					ID          json.Number `json:"id"`
-					Name        string `json:"name"`
-					Description string `json:"description"`
-					UpdatedAt   string `json:"updated_at"`
-					LastUpdBy   string `json:"last_updated_by"`
+					Name        string      `json:"name"`
+					Description string      `json:"description"`
+					UpdatedAt   string      `json:"updated_at"`
+					LastUpdBy   string      `json:"last_updated_by"`
 				} `json:"items"`
 				TotalCount int `json:"total_count"`
 			}
@@ -122,10 +122,10 @@ func languageGroupsGetCmd() *cobra.Command {
 
 			var g struct {
 				ID          json.Number `json:"id"`
-				Name        string `json:"name"`
-				Description string `json:"description"`
-				UpdatedAt   string `json:"updated_at"`
-				LastUpdBy   string `json:"last_updated_by"`
+				Name        string      `json:"name"`
+				Description string      `json:"description"`
+				UpdatedAt   string      `json:"updated_at"`
+				LastUpdBy   string      `json:"last_updated_by"`
 			}
 			if err := json.Unmarshal(data, &g); err != nil {
 				output.PrintJSON(data)
@@ -167,8 +167,8 @@ func languageGroupsCreateCmd() *cobra.Command {
 					return fmt.Errorf("required flags: --name (or use --file)")
 				}
 				body = map[string]interface{}{
-					"name":                           name,
-					"language_configs":               []interface{}{},
+					"name":                             name,
+					"language_configs":                 []interface{}{},
 					"skip_current_language_in_message": false,
 				}
 			}

--- a/scripts/syllable-cli/cmd/organizations.go
+++ b/scripts/syllable-cli/cmd/organizations.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 // orgFormFields builds the multipart form-field map for organization update.

--- a/scripts/syllable-cli/cmd/outbound.go
+++ b/scripts/syllable-cli/cmd/outbound.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func outboundCmd() *cobra.Command {
@@ -95,10 +95,10 @@ func outboundBatchesListCmd() *cobra.Command {
 				Items []struct {
 					BatchID    string      `json:"batch_id"`
 					CampaignID json.Number `json:"campaign_id"`
-					Status     string `json:"status"`
-					Paused     bool   `json:"paused"`
-					ExpiresOn  string `json:"expires_on"`
-					CreatedAt  string `json:"created_at"`
+					Status     string      `json:"status"`
+					Paused     bool        `json:"paused"`
+					ExpiresOn  string      `json:"expires_on"`
+					CreatedAt  string      `json:"created_at"`
 				} `json:"items"`
 				TotalCount int `json:"total_count"`
 			}
@@ -343,7 +343,7 @@ func outboundBatchesRequestsCmd() *cobra.Command {
 				return fmt.Errorf("use --file to provide requests body")
 			}
 
-			data, _, err := apiClient.Post("/api/v1/outbound/batches/"+ url.PathEscape(args[0]) +"/requests", body)
+			data, _, err := apiClient.Post("/api/v1/outbound/batches/"+url.PathEscape(args[0])+"/requests", body)
 			if err != nil {
 				return err
 			}
@@ -379,7 +379,7 @@ func outboundBatchesRemoveRequestsCmd() *cobra.Command {
 				return fmt.Errorf("use --file to provide requests body")
 			}
 
-			data, _, err := apiClient.Post("/api/v1/outbound/batches/"+ url.PathEscape(args[0]) +"/remove-requests", body)
+			data, _, err := apiClient.Post("/api/v1/outbound/batches/"+url.PathEscape(args[0])+"/remove-requests", body)
 			if err != nil {
 				return err
 			}
@@ -462,10 +462,10 @@ func outboundCampaignsListCmd() *cobra.Command {
 				Items []struct {
 					ID           json.Number `json:"id"`
 					CampaignName string      `json:"campaign_name"`
-					Description  string `json:"description"`
-					Mode         string `json:"mode"`
-					CallerID     string `json:"caller_id"`
-					UpdatedAt    string `json:"updated_at"`
+					Description  string      `json:"description"`
+					Mode         string      `json:"mode"`
+					CallerID     string      `json:"caller_id"`
+					UpdatedAt    string      `json:"updated_at"`
 				} `json:"items"`
 				TotalCount int `json:"total_count"`
 			}
@@ -518,15 +518,15 @@ func outboundCampaignsGetCmd() *cobra.Command {
 
 			var c struct {
 				ID           json.Number `json:"id"`
-				CampaignName string `json:"campaign_name"`
-				Description  string `json:"description"`
-				Mode         string `json:"mode"`
-				CallerID     string `json:"caller_id"`
-				Source       string `json:"source"`
-				HourlyRate   int    `json:"hourly_rate"`
-				RetryCount   int    `json:"retry_count"`
-				UpdatedAt    string `json:"updated_at"`
-				LastUpdBy    string `json:"last_updated_by"`
+				CampaignName string      `json:"campaign_name"`
+				Description  string      `json:"description"`
+				Mode         string      `json:"mode"`
+				CallerID     string      `json:"caller_id"`
+				Source       string      `json:"source"`
+				HourlyRate   int         `json:"hourly_rate"`
+				RetryCount   int         `json:"retry_count"`
+				UpdatedAt    string      `json:"updated_at"`
+				LastUpdBy    string      `json:"last_updated_by"`
 				Webhooks     []struct {
 					ID              int      `json:"id"`
 					URL             string   `json:"url"`

--- a/scripts/syllable-cli/cmd/permissions.go
+++ b/scripts/syllable-cli/cmd/permissions.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func permissionsCmd() *cobra.Command {

--- a/scripts/syllable-cli/cmd/prompts.go
+++ b/scripts/syllable-cli/cmd/prompts.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func promptsCmd() *cobra.Command {
@@ -70,13 +70,13 @@ func promptsListCmd() *cobra.Command {
 			var result struct {
 				Items []struct {
 					ID          json.Number `json:"id"`
-					Name        string `json:"name"`
-					Description string `json:"description"`
-					Type        string `json:"type"`
-					AgentCount  int    `json:"agent_count"`
-					LastUpdated string `json:"last_updated"`
-					LastUpdBy   string `json:"last_updated_by"`
-					Version     int    `json:"version_number"`
+					Name        string      `json:"name"`
+					Description string      `json:"description"`
+					Type        string      `json:"type"`
+					AgentCount  int         `json:"agent_count"`
+					LastUpdated string      `json:"last_updated"`
+					LastUpdBy   string      `json:"last_updated_by"`
+					Version     int         `json:"version_number"`
 				} `json:"items"`
 				TotalCount int `json:"total_count"`
 			}
@@ -129,14 +129,14 @@ func promptsGetCmd() *cobra.Command {
 
 			var p struct {
 				ID          json.Number `json:"id"`
-				Name        string `json:"name"`
-				Description string `json:"description"`
-				Type        string `json:"type"`
-				AgentCount  int    `json:"agent_count"`
-				LastUpdated string `json:"last_updated"`
-				LastUpdBy   string `json:"last_updated_by"`
-				Version     int    `json:"version_number"`
-				Context     string `json:"context"`
+				Name        string      `json:"name"`
+				Description string      `json:"description"`
+				Type        string      `json:"type"`
+				AgentCount  int         `json:"agent_count"`
+				LastUpdated string      `json:"last_updated"`
+				LastUpdBy   string      `json:"last_updated_by"`
+				Version     int         `json:"version_number"`
+				Context     string      `json:"context"`
 			}
 			if err := json.Unmarshal(data, &p); err != nil {
 				output.PrintJSON(data)

--- a/scripts/syllable-cli/cmd/pronunciations.go
+++ b/scripts/syllable-cli/cmd/pronunciations.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func pronunciationsCmd() *cobra.Command {

--- a/scripts/syllable-cli/cmd/roles.go
+++ b/scripts/syllable-cli/cmd/roles.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func rolesCmd() *cobra.Command {

--- a/scripts/syllable-cli/cmd/root.go
+++ b/scripts/syllable-cli/cmd/root.go
@@ -13,10 +13,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"github.com/asksyllable/syllable-cli/internal/client"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // Version is set at build time via -ldflags "-X github.com/asksyllable/syllable-cli/cmd.Version=x.y.z"

--- a/scripts/syllable-cli/cmd/schema.go
+++ b/scripts/syllable-cli/cmd/schema.go
@@ -6,9 +6,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
 	apispec "github.com/asksyllable/syllable-cli/internal/spec"
+	"github.com/spf13/cobra"
 )
 
 func schemaCmd() *cobra.Command {

--- a/scripts/syllable-cli/cmd/services.go
+++ b/scripts/syllable-cli/cmd/services.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func servicesCmd() *cobra.Command {

--- a/scripts/syllable-cli/cmd/session_debug.go
+++ b/scripts/syllable-cli/cmd/session_debug.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func sessionDebugCmd() *cobra.Command {

--- a/scripts/syllable-cli/cmd/session_labels.go
+++ b/scripts/syllable-cli/cmd/session_labels.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func sessionLabelsCmd() *cobra.Command {

--- a/scripts/syllable-cli/cmd/sessions.go
+++ b/scripts/syllable-cli/cmd/sessions.go
@@ -7,8 +7,8 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func sessionsCmd() *cobra.Command {
@@ -121,14 +121,14 @@ func sessionsListCmd() *cobra.Command {
 
 			var result struct {
 				Items []struct {
-					SessionID    string  `json:"session_id"`
-					Timestamp    string  `json:"timestamp"`
-					AgentName    string  `json:"agent_name"`
-					AgentType    string  `json:"agent_type"`
-					Duration     float64 `json:"duration"`
-					Source       string  `json:"source"`
-					Target       string  `json:"target"`
-					IsTest       bool    `json:"is_test"`
+					SessionID string  `json:"session_id"`
+					Timestamp string  `json:"timestamp"`
+					AgentName string  `json:"agent_name"`
+					AgentType string  `json:"agent_type"`
+					Duration  float64 `json:"duration"`
+					Source    string  `json:"source"`
+					Target    string  `json:"target"`
+					IsTest    bool    `json:"is_test"`
 				} `json:"items"`
 				TotalCount *int `json:"total_count"`
 			}
@@ -192,18 +192,18 @@ func sessionsGetCmd() *cobra.Command {
 			}
 
 			var s struct {
-				SessionID                  string   `json:"session_id"`
-				ConversationID             string   `json:"conversation_id"`
-				Timestamp                  string   `json:"timestamp"`
-				AgentName                  string   `json:"agent_name"`
-				AgentType                  string   `json:"agent_type"`
-				AgentTimezone              string   `json:"agent_timezone"`
-				PromptName                 string   `json:"prompt_name"`
-				Duration                   float64  `json:"duration"`
-				Source                     string   `json:"source"`
-				Target                     string   `json:"target"`
-				IsTest                     bool     `json:"is_test"`
-				TransferVoicemailDetected  *bool    `json:"transfer_voicemail_detected"`
+				SessionID                 string  `json:"session_id"`
+				ConversationID            string  `json:"conversation_id"`
+				Timestamp                 string  `json:"timestamp"`
+				AgentName                 string  `json:"agent_name"`
+				AgentType                 string  `json:"agent_type"`
+				AgentTimezone             string  `json:"agent_timezone"`
+				PromptName                string  `json:"prompt_name"`
+				Duration                  float64 `json:"duration"`
+				Source                    string  `json:"source"`
+				Target                    string  `json:"target"`
+				IsTest                    bool    `json:"is_test"`
+				TransferVoicemailDetected *bool   `json:"transfer_voicemail_detected"`
 			}
 			if err := json.Unmarshal(data, &s); err != nil {
 				output.PrintJSON(data)
@@ -259,7 +259,7 @@ func sessionsTranscriptCmd() *cobra.Command {
 			}
 
 			var result struct {
-				SessionID    string `json:"session_id"`
+				SessionID     string `json:"session_id"`
 				Transcription []struct {
 					Source    string `json:"source"`
 					Text      string `json:"text"`

--- a/scripts/syllable-cli/cmd/setup.go
+++ b/scripts/syllable-cli/cmd/setup.go
@@ -26,11 +26,11 @@ import (
 // ---------------------------------------------------------------------------
 
 type setupConfig struct {
-	DefaultOrg   string                `yaml:"default_org,omitempty"   json:"default_org"`
-	DefaultEnv   string                `yaml:"default_env,omitempty"   json:"default_env"`
-	Email        string                `yaml:"email,omitempty"         json:"email"`
-	Environments map[string]setupEnv   `yaml:"environments,omitempty"  json:"environments"`
-	Orgs         map[string]setupOrg   `yaml:"orgs,omitempty"          json:"orgs"`
+	DefaultOrg   string              `yaml:"default_org,omitempty"   json:"default_org"`
+	DefaultEnv   string              `yaml:"default_env,omitempty"   json:"default_env"`
+	Email        string              `yaml:"email,omitempty"         json:"email"`
+	Environments map[string]setupEnv `yaml:"environments,omitempty"  json:"environments"`
+	Orgs         map[string]setupOrg `yaml:"orgs,omitempty"          json:"orgs"`
 }
 
 type setupEnv struct {
@@ -38,8 +38,8 @@ type setupEnv struct {
 }
 
 type setupOrg struct {
-	APIKey string                  `yaml:"api_key,omitempty" json:"api_key"`
-	Envs   map[string]setupOrgEnv  `yaml:"envs,omitempty"    json:"envs"`
+	APIKey string                 `yaml:"api_key,omitempty" json:"api_key"`
+	Envs   map[string]setupOrgEnv `yaml:"envs,omitempty"    json:"envs"`
 }
 
 type setupOrgEnv struct {
@@ -54,9 +54,9 @@ const setupKeyPlaceholder = "__existing__"
 
 func setupCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "setup",
-		Short: "Configure orgs, API keys, and environments",
-		Long:  "Opens a browser-based UI to configure ~/.syllable/config.yaml.\nExisting API keys are never sent to the browser.",
+		Use:     "setup",
+		Short:   "Configure orgs, API keys, and environments",
+		Long:    "Opens a browser-based UI to configure ~/.syllable/config.yaml.\nExisting API keys are never sent to the browser.",
 		Example: `  syllable setup`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfgPath, err := setupConfigFilePath()

--- a/scripts/syllable-cli/cmd/status.go
+++ b/scripts/syllable-cli/cmd/status.go
@@ -13,9 +13,9 @@ import (
 
 func statusCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "status",
-		Short: "Show configuration status",
-		Long:  "Reports whether the CLI is configured and lists available orgs and environments.\nExits with code 1 if not configured (no orgs found).",
+		Use:     "status",
+		Short:   "Show configuration status",
+		Long:    "Reports whether the CLI is configured and lists available orgs and environments.\nExits with code 1 if not configured (no orgs found).",
 		Example: `  syllable status`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			home, _ := os.UserHomeDir()

--- a/scripts/syllable-cli/cmd/takeouts.go
+++ b/scripts/syllable-cli/cmd/takeouts.go
@@ -6,8 +6,8 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func takeoutsCmd() *cobra.Command {

--- a/scripts/syllable-cli/cmd/tools.go
+++ b/scripts/syllable-cli/cmd/tools.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/client"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func toolsCmd() *cobra.Command {
@@ -143,8 +143,8 @@ func toolsListCmd() *cobra.Command {
 					Name        string      `json:"name"`
 					ServiceName string      `json:"service_name"`
 					ServiceID   json.Number `json:"service_id"`
-					LastUpdated string `json:"last_updated"`
-					LastUpdBy   string `json:"last_updated_by"`
+					LastUpdated string      `json:"last_updated"`
+					LastUpdBy   string      `json:"last_updated_by"`
 				} `json:"items"`
 				TotalCount int `json:"total_count"`
 			}
@@ -252,8 +252,8 @@ func toolsGetCmd() *cobra.Command {
 				Name        string      `json:"name"`
 				ServiceName string      `json:"service_name"`
 				ServiceID   json.Number `json:"service_id"`
-				LastUpdated string `json:"last_updated"`
-				LastUpdBy   string `json:"last_updated_by"`
+				LastUpdated string      `json:"last_updated"`
+				LastUpdBy   string      `json:"last_updated_by"`
 			}
 			if err := json.Unmarshal(data, &t); err != nil {
 				output.PrintJSON(data)

--- a/scripts/syllable-cli/cmd/users.go
+++ b/scripts/syllable-cli/cmd/users.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/asksyllable/syllable-cli/internal/output"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/asksyllable/syllable-cli/internal/output"
 )
 
 func usersCmd() *cobra.Command {
@@ -419,7 +419,7 @@ func usersSendEmailCmd() *cobra.Command {
 		Short: "Send an email to a user",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Post("/api/v1/users/"+ url.PathEscape(args[0]) +"/send_email", map[string]interface{}{})
+			data, _, err := apiClient.Post("/api/v1/users/"+url.PathEscape(args[0])+"/send_email", map[string]interface{}{})
 			if err != nil {
 				return err
 			}

--- a/scripts/syllable-cli/cmd/voice_groups.go
+++ b/scripts/syllable-cli/cmd/voice_groups.go
@@ -6,8 +6,8 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/spf13/cobra"
 	"github.com/asksyllable/syllable-cli/internal/output"
+	"github.com/spf13/cobra"
 )
 
 func voiceGroupsCmd() *cobra.Command {

--- a/scripts/syllable-cli/go.mod
+++ b/scripts/syllable-cli/go.mod
@@ -1,6 +1,8 @@
 module github.com/asksyllable/syllable-cli
 
-go 1.21
+go 1.24
+
+toolchain go1.26.1
 
 require (
 	github.com/spf13/cobra v1.8.0

--- a/scripts/syllable-cli/integration/helpers_test.go
+++ b/scripts/syllable-cli/integration/helpers_test.go
@@ -27,7 +27,8 @@ var (
 // Auth (either works):
 //   - SYLLABLE_API_KEY — the CLI reads this key directly (non-interactive / CI).
 //   - SYLLABLE_ORG     — the CLI resolves that org's key from ~/.syllable/config.yaml
-//                        (local dev; configure it with `syllable setup`).
+//     (local dev; configure it with `syllable setup`).
+//
 // The CLI has no --api-key/--base-url flag. Set SYLLABLE_ENV for a non-default
 // environment; base URL defaults to prod (https://api.syllable.cloud).
 func initConfig() {

--- a/scripts/syllable-cli/integration/integration_test.go
+++ b/scripts/syllable-cli/integration/integration_test.go
@@ -110,12 +110,12 @@ func TestCustomMessagesCRUD(t *testing.T) {
 	// Update
 	updName := name + " Updated"
 	updateBody := map[string]interface{}{
-		"id":      id,
-		"name":    updName,
-		"text":    "Hello, this is an updated test greeting.",
-		"type":    "greeting",
-		"label":   "",
-		"rules":   []interface{}{},
+		"id":       id,
+		"name":     updName,
+		"text":     "Hello, this is an updated test greeting.",
+		"type":     "greeting",
+		"label":    "",
+		"rules":    []interface{}{},
 		"preamble": nil,
 		"subject":  nil,
 	}
@@ -225,20 +225,20 @@ func TestAgentsCRUD(t *testing.T) {
 
 	name := testName("Agent")
 	createBody := map[string]interface{}{
-		"name":              name,
-		"description":       "Integration test agent",
-		"type":              "ca_v1",
-		"prompt_id":         promptID,
-		"custom_message_id": greetingID,
-		"language_group_id": nil,
-		"timezone":          "America/New_York",
-		"stt_provider":      "Deepgram Nova 3",
-		"wait_sound":        "Keyboard 1",
-		"agent_initiated":   false,
-		"variables":         map[string]interface{}{},
-		"tool_headers":      map[string]interface{}{},
+		"name":                 name,
+		"description":          "Integration test agent",
+		"type":                 "ca_v1",
+		"prompt_id":            promptID,
+		"custom_message_id":    greetingID,
+		"language_group_id":    nil,
+		"timezone":             "America/New_York",
+		"stt_provider":         "Deepgram Nova 3",
+		"wait_sound":           "Keyboard 1",
+		"agent_initiated":      false,
+		"variables":            map[string]interface{}{},
+		"tool_headers":         map[string]interface{}{},
 		"prompt_tool_defaults": []interface{}{},
-		"labels":            []interface{}{},
+		"labels":               []interface{}{},
 	}
 	af := writeTempJSON(t, createBody)
 
@@ -262,21 +262,21 @@ func TestAgentsCRUD(t *testing.T) {
 	// Update
 	updName := name + " Updated"
 	updateBody := map[string]interface{}{
-		"id":                id,
-		"name":              updName,
-		"description":       "Updated integration test agent",
-		"type":              "ca_v1",
-		"prompt_id":         promptID,
-		"custom_message_id": greetingID,
-		"language_group_id": nil,
-		"timezone":          "America/New_York",
-		"stt_provider":      "Deepgram Nova 3",
-		"wait_sound":        "Keyboard 1",
-		"agent_initiated":   false,
-		"variables":         map[string]interface{}{},
-		"tool_headers":      map[string]interface{}{},
+		"id":                   id,
+		"name":                 updName,
+		"description":          "Updated integration test agent",
+		"type":                 "ca_v1",
+		"prompt_id":            promptID,
+		"custom_message_id":    greetingID,
+		"language_group_id":    nil,
+		"timezone":             "America/New_York",
+		"stt_provider":         "Deepgram Nova 3",
+		"wait_sound":           "Keyboard 1",
+		"agent_initiated":      false,
+		"variables":            map[string]interface{}{},
+		"tool_headers":         map[string]interface{}{},
 		"prompt_tool_defaults": []interface{}{},
-		"labels":            []interface{}{},
+		"labels":               []interface{}{},
 	}
 	uf := writeTempJSON(t, updateBody)
 	out = mustRunCLI(t, "agents", "update", id, "--file", uf)


### PR DESCRIPTION
#135 — moves the project off the EOL Go 1.21 toolchain and locks formatting in CI.

- `go.mod`: `go 1.24` + `toolchain go1.26.1` (was `go 1.21`, end-of-life since early 2024). CI and shipped release binaries now build on a supported toolchain that matches local dev.
- One-time `gofmt -w` across the module — struct-literal alignment drift that had accumulated under version skew. Purely mechanical, no behavior change (the bulk of the diff).
- `test.yml`: a **Format and vet** gate that fails on `gofmt` drift and runs `go vet`, so formatting/vet regressions are caught in CI — especially valuable for the self-merging spec-sync automation.

`go build`/`vet`/`test -race` green; `gofmt -l` clean.

Closes #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)