### PR TITLE
Code review batch 6: test coverage — path-contract, helpers, untested families, integration hardening

### DIFF
--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -3038,6 +3038,57 @@ func TestWarnIfInsecureBaseURL(t *testing.T) {
 	}
 }
 
+func TestHint422NamesFields(t *testing.T) {
+	body := []byte(`{"detail":[{"loc":["body","prompt_id"],"msg":"field required"},{"loc":["body","name"],"msg":"x"}]}`)
+	h := hint422(body)
+	if !strings.Contains(h, "prompt_id") || !strings.Contains(h, "name") {
+		t.Errorf("hint422 should name the failing fields, got %q", h)
+	}
+}
+
+func TestHintForErrorStatusCodes(t *testing.T) {
+	cases := map[int]string{
+		401: "API key",
+		403: "permission",
+		500: "Server error",
+	}
+	for code, want := range cases {
+		err := &client.APIError{StatusCode: code, Body: []byte("{}")}
+		if h := hintForError(nil, err); !strings.Contains(h, want) {
+			t.Errorf("hintForError(%d) = %q, want substring %q", code, h, want)
+		}
+	}
+}
+
+func TestResolveBaseURL(t *testing.T) {
+	saveEnv, saveDef := viper.GetString("env"), viper.GetString("default_env")
+	defer func() {
+		viper.Set("env", saveEnv)
+		viper.Set("default_env", saveDef)
+		viper.Set("environments", nil)
+	}()
+	viper.Set("default_env", "")
+
+	viper.Set("env", "")
+	if u, err := resolveBaseURL(); err != nil || u != "https://api.syllable.cloud" {
+		t.Errorf("default base URL = %q, %v", u, err)
+	}
+	viper.Set("env", "prod")
+	if u, err := resolveBaseURL(); err != nil || u != "https://api.syllable.cloud" {
+		t.Errorf("prod builtin base URL = %q, %v", u, err)
+	}
+	viper.Set("environments", map[string]interface{}{"dev": map[string]interface{}{"base_url": "http://localhost:9999"}})
+	viper.Set("env", "dev")
+	if u, err := resolveBaseURL(); err != nil || u != "http://localhost:9999" {
+		t.Errorf("config-defined env base URL = %q, %v", u, err)
+	}
+	viper.Set("env", "ghost")
+	viper.Set("environments", nil)
+	if _, err := resolveBaseURL(); err == nil {
+		t.Error("expected error for an unknown env")
+	}
+}
+
 func TestValidateOutputFmt(t *testing.T) {
 	prev := viper.GetString("output")
 	defer viper.Set("output", prev)
@@ -3053,3 +3104,81 @@ func TestValidateOutputFmt(t *testing.T) {
 		t.Error(`validateOutputFmt("yaml") = nil, want error`)
 	}
 }
+
+// --- Behavioral tests for previously untested command families (#136) ---
+
+// assertBodyIDUpdate exercises a collection-style PUT that routes by the body's
+// id: the positional id must be injected, and a conflicting body id refused.
+func assertBodyIDUpdate(t *testing.T, newCmd func() *cobra.Command, wantPath string) {
+	t.Helper()
+	var got map[string]interface{}
+	var method, path string
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		method, path = r.Method, r.URL.Path
+		json.NewDecoder(r.Body).Decode(&got)
+		w.Write([]byte(`{}`))
+	})
+	defer server.Close()
+
+	cmd := newCmd()
+	cmd.SetArgs([]string{"7", "--file", writeTempJSON(t, `{"name":"x"}`)})
+	captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if method != http.MethodPut || path != wantPath {
+		t.Errorf("expected PUT %s, got %s %s", wantPath, method, path)
+	}
+	if got["id"] != float64(7) {
+		t.Errorf("expected id=7 injected into body, got %#v", got["id"])
+	}
+
+	cmd = newCmd()
+	cmd.SetArgs([]string{"7", "--file", writeTempJSON(t, `{"id":9}`)})
+	cmd.SilenceErrors, cmd.SilenceUsage = true, true
+	var err error
+	captureStdout(func() { err = cmd.Execute() })
+	if err == nil || !strings.Contains(err.Error(), "conflict") {
+		t.Errorf("expected a conflict error on mismatched body id, got %v", err)
+	}
+}
+
+func TestPromptsUpdateInjectsPositionalID(t *testing.T) {
+	assertBodyIDUpdate(t, promptsUpdateCmd, "/api/v1/prompts/")
+}
+
+func TestCustomMessagesUpdateInjectsPositionalID(t *testing.T) {
+	assertBodyIDUpdate(t, customMessagesUpdateCmd, "/api/v1/custom_messages/")
+}
+
+func TestLanguageGroupsUpdateInjectsPositionalID(t *testing.T) {
+	assertBodyIDUpdate(t, languageGroupsUpdateCmd, "/api/v1/language_groups/")
+}
+
+// assertListPath checks a list command issues a GET to the expected path prefix.
+func assertListPath(t *testing.T, newCmd func() *cobra.Command, wantPrefix string) {
+	t.Helper()
+	var method, path string
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		method, path = r.Method, r.URL.Path
+		w.Write([]byte(`{"items":[],"total_count":0}`))
+	})
+	defer server.Close()
+	cmd := newCmd()
+	cmd.SetArgs(nil)
+	captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	if method != http.MethodGet || path != wantPrefix {
+		t.Errorf("expected GET %s, got %s %s", wantPrefix, method, path)
+	}
+}
+
+func TestConversationsList(t *testing.T) {
+	assertListPath(t, conversationsListCmd, "/api/v1/conversations/")
+}
+func TestEventsList(t *testing.T)      { assertListPath(t, eventsListCmd, "/api/v1/events/") }
+func TestPermissionsList(t *testing.T) { assertListPath(t, permissionsListCmd, "/api/v1/permissions/") }

--- a/scripts/syllable-cli/integration/helpers_test.go
+++ b/scripts/syllable-cli/integration/helpers_test.go
@@ -67,6 +67,19 @@ func runCleanup() {
 	}
 }
 
+// registerDelete schedules a cleanup that runs the CLI (typically a delete) and
+// logs any failure to stderr instead of silently leaking the resource (#139).
+func registerDelete(args ...string) {
+	registerCleanup(func() {
+		out, err := runCLI(args...)
+		// A 404 means the test already deleted it on the happy path — not a leak,
+		// so only surface genuine cleanup failures.
+		if err != nil && !strings.Contains(string(out), "404") && !strings.Contains(strings.ToLower(string(out)), "not found") {
+			fmt.Fprintf(os.Stderr, "cleanup failed: %s: %v\n%s\n", strings.Join(args, " "), err, out)
+		}
+	})
+}
+
 // ---------------------------------------------------------------------------
 // CLI runner
 // ---------------------------------------------------------------------------
@@ -75,7 +88,10 @@ func runCleanup() {
 // --org when SYLLABLE_ORG is set and --env when SYLLABLE_ENV is set). The CLI
 // gets its key from SYLLABLE_API_KEY (inherited env) or that org's config entry.
 func runCLI(args ...string) ([]byte, error) {
-	base := []string{"-o", "json"}
+	// --yes skips the destructive-action confirmation prompt; it's a persistent
+	// flag that non-destructive commands ignore, so injecting it unconditionally
+	// keeps delete steps and cleanup working in this non-interactive suite (#118/#139).
+	base := []string{"-o", "json", "--yes"}
 	if org != "" {
 		base = append(base, "--org", org)
 	}
@@ -162,7 +178,9 @@ func writeTempJSON(t *testing.T, v interface{}) string {
 
 // testName returns a unique resource name with a test prefix.
 func testName(suffix string) string {
-	return "[TEST-INTEG] " + suffix
+	// Suffix with the PID so concurrent runs (e.g. a scheduled run overlapping a
+	// labeled-PR run) don't fight over identically-named resources (#139).
+	return fmt.Sprintf("[TEST-INTEG] %s %d", suffix, os.Getpid())
 }
 
 // assertContains fails the test if sub is not found in s.

--- a/scripts/syllable-cli/integration/integration_test.go
+++ b/scripts/syllable-cli/integration/integration_test.go
@@ -19,6 +19,8 @@ package integration_test
 import (
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 	"testing"
 )
 
@@ -34,6 +36,17 @@ func TestMain(m *testing.M) {
 		fmt.Fprintln(os.Stderr, "Set SYLLABLE_API_KEY or SYLLABLE_ORG to run integration tests")
 		os.Exit(0)
 	}
+
+	// Run cleanup even on Ctrl+C / kill, so an aborted run doesn't leak the
+	// resources it created into the test org (#139).
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		fmt.Fprintln(os.Stderr, "interrupted — cleaning up created test resources")
+		runCleanup()
+		os.Exit(1)
+	}()
 
 	code := m.Run()
 	runCleanup()
@@ -52,9 +65,7 @@ func TestLanguageGroupsCRUD(t *testing.T) {
 	id := mustExtractField(t, out, "id")
 	t.Logf("created language group id=%s", id)
 
-	registerCleanup(func() {
-		runCLI("language-groups", "delete", id)
-	})
+	registerDelete("language-groups", "delete", id)
 
 	// Get
 	out = mustRunCLI(t, "language-groups", "get", id)
@@ -95,9 +106,7 @@ func TestCustomMessagesCRUD(t *testing.T) {
 	id := mustExtractField(t, out, "id")
 	t.Logf("created custom message id=%s", id)
 
-	registerCleanup(func() {
-		runCLI("custom-messages", "delete", id)
-	})
+	registerDelete("custom-messages", "delete", id)
 
 	// Get
 	out = mustRunCLI(t, "custom-messages", "get", id)
@@ -154,9 +163,7 @@ func TestPromptsCRUD(t *testing.T) {
 	id := mustExtractField(t, out, "id")
 	t.Logf("created prompt id=%s", id)
 
-	registerCleanup(func() {
-		runCLI("prompts", "delete", id)
-	})
+	registerDelete("prompts", "delete", id)
 
 	// Get
 	out = mustRunCLI(t, "prompts", "get", id)
@@ -204,7 +211,7 @@ func TestAgentsCRUD(t *testing.T) {
 	gf := writeTempJSON(t, greetingBody)
 	gOut := mustRunCLI(t, "custom-messages", "create", "--file", gf)
 	greetingID := mustExtractField(t, gOut, "id")
-	registerCleanup(func() { runCLI("custom-messages", "delete", greetingID) })
+	registerDelete("custom-messages", "delete", greetingID)
 
 	promptBody := map[string]interface{}{
 		"name":    testName("Agent Prompt"),
@@ -221,7 +228,7 @@ func TestAgentsCRUD(t *testing.T) {
 	pf := writeTempJSON(t, promptBody)
 	pOut := mustRunCLI(t, "prompts", "create", "--file", pf)
 	promptID := mustExtractField(t, pOut, "id")
-	registerCleanup(func() { runCLI("prompts", "delete", promptID) })
+	registerDelete("prompts", "delete", promptID)
 
 	name := testName("Agent")
 	createBody := map[string]interface{}{
@@ -247,9 +254,7 @@ func TestAgentsCRUD(t *testing.T) {
 	id := mustExtractField(t, out, "id")
 	t.Logf("created agent id=%s", id)
 
-	registerCleanup(func() {
-		runCLI("agents", "delete", id)
-	})
+	registerDelete("agents", "delete", id)
 
 	// Get
 	out = mustRunCLI(t, "agents", "get", id)
@@ -301,9 +306,7 @@ func TestDirectoryCRUD(t *testing.T) {
 	id := mustExtractField(t, out, "id")
 	t.Logf("created directory member id=%s", id)
 
-	registerCleanup(func() {
-		runCLI("directory", "delete", id)
-	})
+	registerDelete("directory", "delete", id)
 
 	// Get
 	out = mustRunCLI(t, "directory", "get", id)
@@ -370,9 +373,7 @@ func TestToolsCRUD(t *testing.T) {
 	name := mustExtractField(t, out, "name")
 	t.Logf("created tool name=%s", name)
 
-	registerCleanup(func() {
-		runCLI("tools", "delete", name)
-	})
+	registerDelete("tools", "delete", name)
 
 	// Get (uses name, not ID)
 	out = mustRunCLI(t, "tools", "get", name)
@@ -432,9 +433,7 @@ func TestOutboundCampaignsCRUD(t *testing.T) {
 	id := mustExtractField(t, out, "id")
 	t.Logf("created outbound campaign id=%s", id)
 
-	registerCleanup(func() {
-		runCLI("outbound", "campaigns", "delete", id)
-	})
+	registerDelete("outbound", "campaigns", "delete", id)
 
 	// Get
 	out = mustRunCLI(t, "outbound", "campaigns", "get", id)
@@ -484,9 +483,7 @@ func TestOrganizationsSipIPRangesCRUD(t *testing.T) {
 	out := mustRunCLI(t, "organizations", "sip-ip-ranges", "create", "--type", "signaling", "--ip-range", cidr)
 	id := mustExtractField(t, out, "id")
 	t.Logf("created sip-ip-range id=%s", id)
-	registerCleanup(func() {
-		runCLI("organizations", "sip-ip-ranges", "delete", id)
-	})
+	registerDelete("organizations", "sip-ip-ranges", "delete", id)
 
 	// List — should include the range we created
 	out = mustRunCLI(t, "organizations", "sip-ip-ranges", "list")

--- a/scripts/syllable-cli/internal/client/client_test.go
+++ b/scripts/syllable-cli/internal/client/client_test.go
@@ -273,3 +273,22 @@ func TestCheckRedirectStripsKeyCrossHost(t *testing.T) {
 		t.Error("expected an error after 10 redirects")
 	}
 }
+
+func TestMaskKey(t *testing.T) {
+	cases := map[string]string{
+		"":               "****",     // empty
+		"short":          "****",     // <= 8 chars: fully masked
+		"12345678":       "****",     // exactly 8
+		"123456789":      "1234****", // > 8: short prefix only, no suffix or length
+		"syl_abcdef1234": "syl_****",
+	}
+	for in, want := range cases {
+		if got := maskKey(in); got != want {
+			t.Errorf("maskKey(%q) = %q, want %q", in, got, want)
+		}
+		// Never leak the tail of a key.
+		if len(in) > 8 && strings.Contains(maskKey(in), in[len(in)-4:]) {
+			t.Errorf("maskKey(%q) leaked the key suffix", in)
+		}
+	}
+}

--- a/scripts/syllable-cli/internal/spec/spec_test.go
+++ b/scripts/syllable-cli/internal/spec/spec_test.go
@@ -2,6 +2,10 @@ package spec
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -74,4 +78,66 @@ func TestBulkOperationPathsMatch(t *testing.T) {
 			t.Errorf("bulk operation path %q missing from spec — CLI command will hit a slash-mismatch redirect", p)
 		}
 	}
+}
+
+// TestCLIPathsExistInSpec extracts every "/api/v1/..." string literal from the
+// cmd/*.go sources and asserts each one's static prefix corresponds to a real
+// endpoint in the embedded spec. This mechanically catches typo'd or removed
+// paths (the class behind #114) in CI instead of via a live 404/405 (#117).
+//
+// It's a prefix check at a segment boundary: the dynamic tail of a path is built
+// at runtime (concatenation or %s), so we verify the static resource prefix is
+// real, not the full templated path.
+func TestCLIPathsExistInSpec(t *testing.T) {
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(OpenAPI, &parsed); err != nil {
+		t.Fatalf("spec not valid JSON: %v", err)
+	}
+	pathsMap := parsed["paths"].(map[string]interface{})
+	specPaths := make([]string, 0, len(pathsMap))
+	for p := range pathsMap {
+		specPaths = append(specPaths, p)
+	}
+
+	files, err := filepath.Glob("../../cmd/*.go")
+	if err != nil || len(files) == 0 {
+		t.Fatalf("could not list cmd sources: %v", err)
+	}
+	re := regexp.MustCompile(`"(/api/v1/[^"]*)"`)
+	checked := 0
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, m := range re.FindAllStringSubmatch(string(src), -1) {
+			// Static prefix: up to the first format verb or query, trimmed to a segment.
+			prefix := m[1]
+			if i := strings.IndexAny(prefix, "%?"); i >= 0 {
+				prefix = prefix[:i]
+			}
+			prefix = strings.TrimRight(prefix, "/")
+			if prefix == "/api/v1" || prefix == "" {
+				continue // too generic to be meaningful
+			}
+			ok := false
+			for _, sp := range specPaths {
+				if sp == prefix || strings.HasPrefix(sp, prefix+"/") {
+					ok = true
+					break
+				}
+			}
+			if !ok {
+				t.Errorf("%s: path %q has no matching endpoint in the embedded spec (static prefix %q)", filepath.Base(f), m[1], prefix)
+			}
+			checked++
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no /api/v1 path literals found in cmd/*.go — the extractor is broken")
+	}
+	t.Logf("checked %d CLI path literals against the spec", checked)
 }


### PR DESCRIPTION
Test-coverage backlog — 4 issues. `go test -race ./...` green; integration compiles under `-tags integration`.

- **#117** — `TestCLIPathsExistInSpec` extracts every `/api/v1` path literal from `cmd/*.go` and asserts its static prefix exists in the embedded spec (172 literals checked). Catches typod/removed paths in CI instead of via a live 404/405 — the prevention for the #114 class.
- **#136** — behavioral tests for previously-zero-coverage families: the body-routed PUT guards for prompts/custom-messages/language-groups (the #68 silent-wrong-resource class), plus list tests for conversations/events/permissions.
- **#138** — helper edge cases: `maskKey` (no suffix/length leak), `hint422` field extraction, `hintForError` status hints, `resolveBaseURL` precedence.
- **#139** — integration suite: per-PID unique resource names (no collisions across overlapping runs), cleanup on SIGINT/SIGTERM, and a `registerDelete` helper that logs genuine cleanup failures (suppressing the expected post-delete 404). Also injects `--yes` into the suites `runCLI` so delete steps keep working non-interactively after the #118 confirmation gate.

Closes #117, #136, #138, #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)