### PR TITLE
Code review batch 7: consistent update-command contract (#121)

### DIFF
--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -3182,3 +3182,23 @@ func TestConversationsList(t *testing.T) {
 }
 func TestEventsList(t *testing.T)      { assertListPath(t, eventsListCmd, "/api/v1/events/") }
 func TestPermissionsList(t *testing.T) { assertListPath(t, permissionsListCmd, "/api/v1/permissions/") }
+
+// --- Update-command contract consistency (#121) ---
+// These five previously took no positional (id had to live in --file); they now
+// accept an optional positional id reconciled via ensureBodyIdentifier.
+
+func TestDataSourcesUpdateInjectsPositionalID(t *testing.T) {
+	assertBodyIDUpdate(t, dataSourcesUpdateCmd, "/api/v1/data_sources/")
+}
+func TestServicesUpdateInjectsPositionalID(t *testing.T) {
+	assertBodyIDUpdate(t, servicesUpdateCmd, "/api/v1/services/")
+}
+func TestVoiceGroupsUpdateInjectsPositionalID(t *testing.T) {
+	assertBodyIDUpdate(t, voiceGroupsUpdateCmd, "/api/v1/voice_groups/")
+}
+func TestRolesUpdateInjectsPositionalID(t *testing.T) {
+	assertBodyIDUpdate(t, rolesUpdateCmd, "/api/v1/roles/")
+}
+func TestIncidentsUpdateInjectsPositionalID(t *testing.T) {
+	assertBodyIDUpdate(t, incidentsUpdateCmd, "/api/v1/incidents/")
+}

--- a/scripts/syllable-cli/cmd/data_sources.go
+++ b/scripts/syllable-cli/cmd/data_sources.go
@@ -200,7 +200,8 @@ func dataSourcesUpdateCmd() *cobra.Command {
 	var file string
 
 	cmd := &cobra.Command{
-		Use:   "update",
+		Use:   "update [id]",
+		Args:  cobra.MaximumNArgs(1),
 		Short: "Update a data source",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var body interface{}
@@ -217,6 +218,13 @@ func dataSourcesUpdateCmd() *cobra.Command {
 				return fmt.Errorf("use --file to provide update body")
 			}
 
+			// An optional positional id is reconciled with the body id, which the
+			// collection PUT routes by — matching the agents/prompts shape (#121, #68).
+			if len(args) == 1 {
+				if err := ensureBodyIdentifier(body, "id", args[0], true); err != nil {
+					return err
+				}
+			}
 			data, _, err := apiClient.Put("/api/v1/data_sources/", body)
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/incidents.go
+++ b/scripts/syllable-cli/cmd/incidents.go
@@ -166,7 +166,8 @@ func incidentsUpdateCmd() *cobra.Command {
 	var file string
 
 	cmd := &cobra.Command{
-		Use:   "update",
+		Use:   "update [id]",
+		Args:  cobra.MaximumNArgs(1),
 		Short: "Update an incident",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var body interface{}
@@ -183,6 +184,13 @@ func incidentsUpdateCmd() *cobra.Command {
 				return fmt.Errorf("use --file to provide update body")
 			}
 
+			// An optional positional id is reconciled with the body id, which the
+			// collection PUT routes by — matching the agents/prompts shape (#121, #68).
+			if len(args) == 1 {
+				if err := ensureBodyIdentifier(body, "id", args[0], true); err != nil {
+					return err
+				}
+			}
 			data, _, err := apiClient.Put("/api/v1/incidents/", body)
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/roles.go
+++ b/scripts/syllable-cli/cmd/roles.go
@@ -195,7 +195,8 @@ func rolesUpdateCmd() *cobra.Command {
 	var file string
 
 	cmd := &cobra.Command{
-		Use:   "update",
+		Use:   "update [id]",
+		Args:  cobra.MaximumNArgs(1),
 		Short: "Update a role",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var body interface{}
@@ -212,6 +213,13 @@ func rolesUpdateCmd() *cobra.Command {
 				return fmt.Errorf("use --file to provide update body")
 			}
 
+			// An optional positional id is reconciled with the body id, which the
+			// collection PUT routes by — matching the agents/prompts shape (#121, #68).
+			if len(args) == 1 {
+				if err := ensureBodyIdentifier(body, "id", args[0], true); err != nil {
+					return err
+				}
+			}
 			data, _, err := apiClient.Put("/api/v1/roles/", body)
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/services.go
+++ b/scripts/syllable-cli/cmd/services.go
@@ -196,7 +196,8 @@ func servicesUpdateCmd() *cobra.Command {
 	var file string
 
 	cmd := &cobra.Command{
-		Use:   "update",
+		Use:   "update [id]",
+		Args:  cobra.MaximumNArgs(1),
 		Short: "Update a service",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var body interface{}
@@ -213,6 +214,13 @@ func servicesUpdateCmd() *cobra.Command {
 				return fmt.Errorf("use --file to provide update body")
 			}
 
+			// An optional positional id is reconciled with the body id, which the
+			// collection PUT routes by — matching the agents/prompts shape (#121, #68).
+			if len(args) == 1 {
+				if err := ensureBodyIdentifier(body, "id", args[0], true); err != nil {
+					return err
+				}
+			}
 			data, _, err := apiClient.Put("/api/v1/services/", body)
 			if err != nil {
 				return err

--- a/scripts/syllable-cli/cmd/voice_groups.go
+++ b/scripts/syllable-cli/cmd/voice_groups.go
@@ -234,7 +234,8 @@ func voiceGroupsUpdateCmd() *cobra.Command {
 	var file string
 
 	cmd := &cobra.Command{
-		Use:   "update",
+		Use:   "update [id]",
+		Args:  cobra.MaximumNArgs(1),
 		Short: "Update a voice group",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var body interface{}
@@ -251,6 +252,13 @@ func voiceGroupsUpdateCmd() *cobra.Command {
 				return fmt.Errorf("use --file to provide update body")
 			}
 
+			// An optional positional id is reconciled with the body id, which the
+			// collection PUT routes by — matching the agents/prompts shape (#121, #68).
+			if len(args) == 1 {
+				if err := ensureBodyIdentifier(body, "id", args[0], true); err != nil {
+					return err
+				}
+			}
 			data, _, err := apiClient.Put("/api/v1/voice_groups/", body)
 			if err != nil {
 				return err


### PR DESCRIPTION
#121 — `data-sources`, `services`, `voice-groups`, `roles`, and `incidents` `update` previously took **no positional** (the id had to live inside `--file`) — an inconsistent contract vs `agents`/`prompts`/`tools`, and still exposed to the #68 silent-wrong-resource risk. They now accept an **optional positional id** reconciled with the body via `ensureBodyIdentifier`, matching the rest of the CLI. New test per resource.

`organizations update` is the singular current-org multipart command and is intentionally unchanged.

Closes #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)