### PR TITLE
Code review batch 8: spec-based --dry-run required-field preflight (#143)

### DIFF
--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -3202,3 +3202,46 @@ func TestRolesUpdateInjectsPositionalID(t *testing.T) {
 func TestIncidentsUpdateInjectsPositionalID(t *testing.T) {
 	assertBodyIDUpdate(t, incidentsUpdateCmd, "/api/v1/incidents/")
 }
+
+// --- Spec-based --dry-run preflight (#143) ---
+
+func TestSpecPreflight(t *testing.T) {
+	has := func(list []string, want string) bool {
+		for _, s := range list {
+			if s == want {
+				return true
+			}
+		}
+		return false
+	}
+
+	// AgentCreate requires name/type/prompt_id/timezone/variables/tool_headers.
+	missing := specPreflight("POST", "/api/v1/agents/", []byte(`{"name":"x"}`))
+	for _, want := range []string{"type", "prompt_id", "timezone"} {
+		if !has(missing, want) {
+			t.Errorf("expected %q reported missing, got %v", want, missing)
+		}
+	}
+	if has(missing, "name") {
+		t.Errorf("name was provided and must not be reported missing: %v", missing)
+	}
+
+	// A complete body reports nothing.
+	if got := specPreflight("POST", "/api/v1/agents/",
+		[]byte(`{"name":"x","type":"ca_v1","prompt_id":1,"timezone":"UTC","variables":{},"tool_headers":{}}`)); len(got) != 0 {
+		t.Errorf("expected no missing fields, got %v", got)
+	}
+
+	// A query string is stripped before lookup.
+	if got := specPreflight("POST", "/api/v1/agents/?x=1", []byte(`{}`)); len(got) == 0 {
+		t.Error("expected missing fields even with a query string present")
+	}
+
+	// Unknown path / non-object body → no findings (best-effort).
+	if got := specPreflight("POST", "/api/v1/nonexistent/", []byte(`{}`)); got != nil {
+		t.Errorf("unknown path should yield nil, got %v", got)
+	}
+	if got := specPreflight("POST", "/api/v1/agents/", []byte(`["not","an","object"]`)); got != nil {
+		t.Errorf("non-object body should yield nil, got %v", got)
+	}
+}

--- a/scripts/syllable-cli/cmd/preflight.go
+++ b/scripts/syllable-cli/cmd/preflight.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+
+	apispec "github.com/asksyllable/syllable-cli/internal/spec"
+)
+
+// specPreflight returns the names of top-level required fields — per the
+// embedded OpenAPI request schema for this path+method — that are absent from
+// the JSON body. It is wired into the client only to annotate --dry-run output
+// (#143), so it never blocks a real request: the spec and prod can legitimately
+// differ, and the server's 422 plus hint422 already handle deep validation.
+//
+// Best-effort and nil-safe: an unknown path/method, a missing requestBody, or a
+// non-object body yields no findings.
+func specPreflight(method, path string, body []byte) []string {
+	if i := strings.IndexByte(path, '?'); i >= 0 {
+		path = path[:i]
+	}
+
+	var doc map[string]interface{}
+	if json.Unmarshal(apispec.OpenAPI, &doc) != nil {
+		return nil
+	}
+	paths, _ := doc["paths"].(map[string]interface{})
+	pathItem, _ := paths[path].(map[string]interface{})
+	op, _ := pathItem[strings.ToLower(method)].(map[string]interface{})
+	rb, _ := op["requestBody"].(map[string]interface{})
+	content, _ := rb["content"].(map[string]interface{})
+	appJSON, _ := content["application/json"].(map[string]interface{})
+	schema, _ := appJSON["schema"].(map[string]interface{})
+	if schema == nil {
+		return nil
+	}
+	// Resolve a $ref to its named component schema.
+	if ref, ok := schema["$ref"].(string); ok {
+		name := ref[strings.LastIndex(ref, "/")+1:]
+		comps, _ := doc["components"].(map[string]interface{})
+		schemas, _ := comps["schemas"].(map[string]interface{})
+		schema, _ = schemas[name].(map[string]interface{})
+	}
+	required, _ := schema["required"].([]interface{})
+	if len(required) == 0 {
+		return nil
+	}
+
+	var parsed map[string]interface{}
+	if json.Unmarshal(body, &parsed) != nil {
+		return nil // not a JSON object — nothing to check
+	}
+	var missing []string
+	for _, r := range required {
+		key, _ := r.(string)
+		if key == "" {
+			continue
+		}
+		if v, present := parsed[key]; !present || v == nil {
+			missing = append(missing, key)
+		}
+	}
+	return missing
+}

--- a/scripts/syllable-cli/cmd/root.go
+++ b/scripts/syllable-cli/cmd/root.go
@@ -343,6 +343,7 @@ func initClient() error {
 	apiClient = client.New(baseURL, key)
 	apiClient.DryRun = dryRun
 	apiClient.Verbose = debugMode
+	apiClient.Preflight = specPreflight
 	return nil
 }
 

--- a/scripts/syllable-cli/internal/client/client.go
+++ b/scripts/syllable-cli/internal/client/client.go
@@ -40,6 +40,11 @@ type Client struct {
 	HTTPClient *http.Client
 	DryRun     bool
 	Verbose    bool
+	// Preflight, when set, returns the names of required request-body fields
+	// missing from a JSON body. It's used only to annotate --dry-run output, so
+	// it never blocks a real request (spec and prod can legitimately differ). The
+	// validator is injected by the cmd layer so this package stays spec-free (#143).
+	Preflight func(method, path string, body []byte) []string
 }
 
 // New creates a new Client.
@@ -140,6 +145,11 @@ func (c *Client) Do(method, path string, body interface{}) ([]byte, int, error) 
 		if bodyBytes != nil {
 			var bodyJSON json.RawMessage = bodyBytes
 			out["body"] = bodyJSON
+			if c.Preflight != nil {
+				if missing := c.Preflight(method, path, bodyBytes); len(missing) > 0 {
+					out["missing_required_fields"] = missing
+				}
+			}
 		}
 		data, _ := json.Marshal(out)
 		return nil, 0, &DryRunResult{Output: data}


### PR DESCRIPTION
#143 — under `--dry-run`, create/update bodies are now checked against the embedded OpenAPI request schema's top-level `required` array, and any absent fields are surfaced as `missing_required_fields` in the dry-run JSON.

Example (`agents create --dry-run` with `{\"name\":\"x\"}`): output includes `\"missing_required_fields\": [\"type\",\"prompt_id\",\"timezone\",\"variables\",\"tool_headers\"]`.

Deliberately **dry-run-only** — it never blocks a real request, since the spec and prod can legitimately differ (cf. the prod-drift issues) and the server's 422 + `hint422` already handle validation. The validator is injected into the client from the cmd layer, so `internal/client` stays spec-free.

Closes #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)