### PR TITLE
fix: data-sources create uses text+chunk (not phantom content) + skill fact-check

### DIFF
--- a/.claude/skills/syllable-cli/SKILL.md
+++ b/.claude/skills/syllable-cli/SKILL.md
@@ -11,7 +11,7 @@ A Go CLI for managing the Syllable AI platform. Source and releases: **https://g
 
 > **Docs synced to CLI v1.8.0** (pending release) — bump this marker whenever these docs are updated for a new release.
 >
-> v1.8.0 highlights for CLI users: destructive `delete` commands now confirm interactively and need `--yes` when non-interactive; `channels delete` was removed (no such API op — use `channels targets delete`); `--output` is validated; unknown `--fields` columns warn; `--dry-run` lists any `missing_required_fields`; `--debug` redacts credentials.
+> v1.8.0 highlights for CLI users: destructive `delete` commands now confirm interactively and need `--yes` when non-interactive; `channels delete` was removed (no such API op — use `channels targets delete`); `--output` is validated; unknown `--fields` columns warn; `--dry-run` lists any `missing_required_fields`; `--debug` redacts credentials; `data-sources create` inline now takes `--text` (the document-body field) in place of the old, non-functional `--content`.
 
 ## Installation
 
@@ -105,7 +105,7 @@ All list commands support these flags:
 | `--search` | — | Search filter (field varies by resource — see table below) |
 | `--search-field` | per-resource default below | Override which field `--search` filters on (free-form, passed to the API as `search_fields`) |
 
-For sessions, the valid `--search-field` values are the `SessionProperties` enum — `syllable schema get SessionProperties` lists them (`agent_name`, `source`, `target`, `channel_manager_sid`, `prompt_name`, `is_outbound`, …). **String fields filter correctly; boolean fields (`is_test`, `is_outbound`) do not as of v1.7.1** — see `references/gotchas.md`.
+For sessions, the valid `--search-field` values are the `SessionProperties` enum — `syllable schema get SessionProperties` lists them (`agent_name`, `source`, `target`, `channel_manager_sid`, `prompt_name`, `is_outbound`, …). **String fields filter server-side; filter boolean fields (`is_test`, `is_outbound`) client-side with `jq`** — see `references/gotchas.md`.
 
 **Default search field by resource:**
 

--- a/.claude/skills/syllable-cli/references/commands.md
+++ b/.claude/skills/syllable-cli/references/commands.md
@@ -58,7 +58,7 @@ syllable agents send-test-message <id> --test-id t1 --session-start --override-t
 syllable agents send-test-message <id> --test-id t1 --override-timestamp "2030-12-25T09:30:00" --text "what's today's date?"
 ```
 
-- **Format must be timezone-naive** `YYYY-MM-DDTHH:MM:SS` (no `-06:00` offset, no `Z`, no space separator). Other forms are silently ignored and fall back to the real clock with no error.
+- **Format must be timezone-naive** `YYYY-MM-DDTHH:MM:SS` (no `-06:00` offset, no `Z`, no space separator). Other forms are ignored and fall back to the real clock.
 - **Per-turn, not sticky** — pass it on every turn you want pinned, including `--session-start`.
 - **Verify it took** via the session transcript `actions[].tool_result` for `get_current_datetime`, not a green run.
 
@@ -178,7 +178,7 @@ syllable sessions recording-stream --token <token>   # stream recording bytes to
 ```bash
 syllable sessions list --search-field channel_manager_sid --search "CA…" -o json
 ```
-**Boolean fields don't filter (v1.7.1):** `--search-field is_outbound` returns nothing for any value; `--search-field is_test --search true` *adds* test sessions instead of restricting to them — filter booleans client-side with `jq` instead (see `gotchas.md`). `--include-test` includes test sessions (channel targets marked `is_test=true`) in the list.
+**Filter boolean fields client-side:** server-side `--search-field` filtering is reliable for string fields; for booleans (`is_outbound`, `is_test`) fetch with `-o json` and filter with `jq` (see `gotchas.md`). `--include-test` includes test sessions (channel targets marked `is_test=true`) in the list.
 
 **Get fields:** Session ID, Conversation ID, Timestamp, Agent, Agent Type, Timezone, Prompt, Duration, Source, Target, Is Test
 
@@ -236,7 +236,7 @@ syllable users send-email <email>
 
 **Get fields:** ID, Email, First Name, Last Name, Role Name, Role ID, Activity Status, Last Updated, Last Updated By, Last Session At
 
-**Note:** Delete uses query parameter (`DELETE /api/v1/users/?email=...`) instead of URL path — unlike other resources.
+**Note:** Delete sends a JSON body (`{ "email": …, "reason": … }`) to `DELETE /api/v1/users/`, not a path or query identifier — unlike other resources.
 
 **`users me` requires a configured email (v1.7):** with your email set via `syllable setup` it does an exact lookup of your account; without one it fails loudly (`Error: no email configured — run \`syllable setup\` …`, exit 1). The API has no key→identity endpoint, so there is no fallback. Pre-1.7 it silently returned the org's first user.
 
@@ -326,8 +326,8 @@ syllable language-groups delete <group-id>
 ```bash
 syllable data-sources list [--page N] [--limit N] [--search name=foo]
 syllable data-sources get <data_source_id>
-syllable data-sources create --file source.json
-syllable data-sources create --name "FAQ" --description "FAQ data" --content "Q&A text..."
+syllable data-sources create --file source.json           # body requires: name, text (document body), chunk
+syllable data-sources create --name "FAQ" --text "Q&A…"   # inline; chunk defaults to false
 syllable data-sources update --file source.json
 syllable data-sources delete <data_source_id>
 ```
@@ -414,9 +414,9 @@ syllable conversation-config bridges                          # get bridge phras
 syllable conversation-config bridges-update --file bridges.json
 ```
 
-**Unified messages (v1.7.1 spec):** the bridges body now supports an ordered `messages` list plus `randomize_messages` (bool, no-repeat shuffling). When `messages` is non-empty it replaces the three legacy lists (`first_slow_messages`, `very_slow_messages`, `tool_responses`); when empty, the legacy fields still apply. Both `bridges` commands are pass-through `--file` bodies. **Caveat:** as of 2026-06-04 the production API accepts these fields with 200 but does **not persist them** — read back after updating (see `gotchas.md` § *Bridge Phrases*). Field semantics in `telephony-and-channels.md` § *Bridge Phrases*.
+**Unified messages (v1.7.1 spec):** the bridges body now supports an ordered `messages` list plus `randomize_messages` (bool, no-repeat shuffling). When `messages` is non-empty it replaces the three legacy lists (`first_slow_messages`, `very_slow_messages`, `tool_responses`); when empty, the legacy fields still apply. Both `bridges` commands are pass-through `--file` bodies. **Caveat:** production doesn't persist these fields yet — read back after updating to confirm (see `gotchas.md` § *Bridge Phrases*). Field semantics in `telephony-and-channels.md` § *Bridge Phrases*.
 
-**Smart-turn timeout (v1.7.2 spec):** the top-level bridges body also accepts `smart_turn_timeout_seconds` (number, `0.25`–`30`, or `null`) — seconds of caller silence before the first bridge phrase fires (later intervals scale 2x/3x/4x); unset uses the service default. Passes through the same `--file` body; documented from release notes, not live-verified — read back to confirm persistence.
+**Smart-turn timeout (v1.7.2 spec):** the top-level bridges body also accepts `smart_turn_timeout_seconds` (number, `0.25`–`30`, or `null`) — seconds of caller silence before the first bridge phrase fires (later intervals scale 2x/3x/4x); unset uses the service default. Passes through the same `--file` body, but production doesn't persist it yet — read back to confirm.
 
 ## Dashboards
 ```bash

--- a/.claude/skills/syllable-cli/references/gotchas.md
+++ b/.claude/skills/syllable-cli/references/gotchas.md
@@ -1,115 +1,115 @@
 # Syllable CLI: Known Gotchas
 
-Consolidated list of CLI and API pitfalls encountered during agent builds. Each entry includes the fix or workaround.
+Practical notes on non-obvious CLI and platform behavior — exact payload shapes, field names, identifier formats, and the occasional read-back to confirm a setting applied. Each row pairs the behavior with what to do.
 
 ## Payload Format
 
-| Issue | Details |
-|-------|---------|
-| `prompt_tool_defaults` `doc` format | Must be a JSON array (`["name"]`), not a string. The API silently accepts strings but they don't work correctly. |
-| Tool endpoint `method` must be lowercase | Use `"get"`, `"post"`, `"put"`, `"delete"` -- not uppercase. Uppercase values are rejected by the API. |
-| Agent create requires `tool_headers` | Include `"tool_headers": {}` in the agent create payload even when empty. Omitting the field can cause validation errors. |
-| Data source `text` field | Data source create uses `text` (not `content`) for the document body. Also requires `chunk: true` as a boolean field. |
-| Greeting `subject` vs `text` field | The `subject` field on `CustomMessageCreateRequest` is only valid for `email_template` type greetings. Using `subject` on a regular greeting causes an API rejection. Use the `text` field for the greeting message body. The `preamble` field holds an optional uninterruptible prefix (e.g., legal disclaimers). |
-| Static parameters API format | The API expects `{"name", "default", "type", "required"}` per static parameter. Some shorthand formats use `{"name", "value"}`. Translate: `value` -> `default`, add `"type": "string"` and `"required": false`. |
-| Agent `variables` format | Use a flat dictionary `{"key": "value"}`, not an array of objects. The array format is silently rejected. Store each custom variable with both keys -- e.g., `{"agent_name": "Anna", "vars.agent_name": "Anna"}` -- so the value renders in both greetings (bare key) and prompts (`vars.` prefix). |
-| `definition.type` required | Tool definitions must include `"type": "endpoint"`. Omitting this causes validation errors. |
+| Topic | What to do |
+|-------|-----------|
+| `prompt_tool_defaults` `doc` format | Provide `doc` as a JSON array (`["name"]`), not a string — only the array form is applied. |
+| Tool endpoint `method` is lowercase | Use `"get"`, `"post"`, `"put"`, `"delete"` (lowercase). |
+| Agent create — include `tool_headers` | Send `"tool_headers": {}` in the agent create payload even when empty. |
+| Data source body field | Data source create requires `name`, `text`, and `chunk` — the document body goes in `text` (not `content`). `chunk` is a required boolean placeholder (currently treated as `false` server-side regardless of value). Inline create takes `--name` + `--text`; use `--file` for full control. |
+| Greeting `subject` vs `text` | `subject` is only accepted on `email_template` messages — including it on a `greeting` is rejected with a 422 (`subject is only allowed when type is email_template`). Put the greeting message in `text`; `preamble` holds an optional uninterruptible prefix (e.g., legal disclaimers). |
+| Static parameter shape | Each static parameter is `{"name", "default", "type", "required"}`. If you have a `{"name", "value"}` shorthand, map `value` → `default` and add `"type": "string"`, `"required": false`. |
+| Agent `variables` shape | Use a flat dictionary `{"key": "value"}`, not an array of objects. Reference each variable by the **same key everywhere** (greeting, prompt, tool parameter) — one key per value, no duplicates. The `vars.` prefix isn't needed for your own variables; it's reserved for system variables (`vars.session.*`) and outbound-campaign variables (auto-prefixed by the campaign system). See `references/variables-and-messages.md`. |
+| Tool `definition.type` | Tool definitions include `"type": "endpoint"`. |
 
 ## CLI Flags & Identifiers
 
-| Issue | Details |
-|-------|---------|
-| CLI JSON input flag | Use `--file /tmp/payload.json` (not `--from-json`). The flag is `--file` for all create and update commands. |
-| Destructive deletes need `--yes` non-interactively (v1.8) | `delete` prompts for a y/N confirmation; with no TTY (scripts, CI, **an agent driving the CLI**) it **refuses unless `--yes`/`-y` is passed** and makes no request. `--dry-run` previews without deleting. Related v1.8 flag changes: `--output` now rejects anything other than `table`/`json`; unknown `--fields` columns warn on stderr (output unchanged); a create/update under `--dry-run` lists any `missing_required_fields` from the embedded spec; `--debug` redacts credential fields (`auth_values`, tokens, secrets); config/auth errors print as JSON under `-o json`. |
-| `prompts update` requires positional ID | `syllable prompts update <id> --file /tmp/prompt.json --org <org>`. Omitting the positional ID causes "accepts 1 arg(s), received 0". |
-| CLI get/update identifier format | `tools update`/`delete` use the tool **name** (string); `prompts get/update` use the numeric **ID**. Since CLI v1.7, `tools get` accepts **either** (an all-digits arg is resolved ID → name via the list endpoint). Still capture both name and ID from create responses — updates and deletes remain name-keyed. |
-| Update body `id` vs positional ID (v1.7) | Body-routed update commands (`agents`, `prompts`, `custom-messages`, `language-groups`, `users` by email, `tools` by name; and since **v1.8** `data-sources`, `services`, `voice-groups`, `roles`, `incidents`, which previously took no positional) now inject the positional identifier into the body when missing, and **hard-error before sending** if the body carries a different one. Pre-1.7 the positional was silently ignored and the body's `id` decided what got updated — on older CLI versions, always carry the right `id` in the body (the standard get → edit → put pipe does). |
-| Session ID vs Twilio call SID | Routes/SDK calls keyed by `session_id` (e.g., `sessions get`, `GET /api/v1/sessions/full-summary/{session_id}`, `sdk.sessions.getById`) require the **numeric** Syllable session ID (e.g., `824`). Passing a Twilio-style `CA<hex>` call SID returns **400** — that value is the session's `channel_manager_sid`, a *different* field. To resolve a `CA…` SID to the session ID in one call: `sessions list --search-field channel_manager_sid --search "<full SID>" -o json` (verified live with a full SID — returned exactly the matching session). On older CLIs without `--search-field`, match the `channel_manager_sid` column on `sessions list -o json`. |
-| Boolean session search fields don't filter | Verified live 2026-06-04 on CLI v1.7.1: `sessions list --search-field is_outbound --search <v>` returns **zero results** for every value form tried (`true`/`false`/`True`/`TRUE`/`1`/`t`/`outbound`) even though the org's sessions had `is_outbound: true` and the field is in the `SessionProperties` enum. `--search-field is_test --search true` doesn't restrict to test sessions either — it returned **more** rows than unfiltered (25 vs 18), behaving like `--include-test`; `false` matched the unfiltered default (18). String fields (`agent_name`, `channel_manager_sid`) filter correctly. **Fix:** fetch with `-o json` and filter client-side, e.g. `… -o json \| jq '.items[] \| select(.is_outbound == true)'`. To *include* test sessions use the dedicated `--include-test` flag. (Re-checked 2026-06-08 on CLI v1.7.3: `is_outbound` now **fails loud with 422** at query validation rather than silently returning zero, even though the v1.7.3 spec still lists `is_outbound` in `SessionProperties` — symptom changed, drift unchanged; client-side `jq` fix still required. Tracked in [cli#99](https://github.com/asksyllable/syllable-cli/issues/99).) |
+| Topic | What to do |
+|-------|-----------|
+| JSON input flag is `--file` | Use `--file /tmp/payload.json` (or `--file -` for stdin) on every create/update — there is no `--from-json`. |
+| Destructive deletes need `--yes` non-interactively (v1.8) | `delete` prompts for a y/N confirmation; with no TTY (scripts, CI, **an agent driving the CLI**) pass `--yes`/`-y` or it makes no request. `--dry-run` previews without deleting. Related v1.8 conveniences: `--output` accepts only `table`/`json`; unknown `--fields` columns warn on stderr (output unchanged); a create/update under `--dry-run` lists any `missing_required_fields` from the embedded spec; `--debug` redacts credential fields (`auth_values`, tokens, secrets); config/auth errors print as JSON under `-o json`. |
+| `prompts update` takes a positional ID | `syllable prompts update <id> --file /tmp/prompt.json --org <org>`. Without it: "accepts 1 arg(s), received 0". |
+| get/update identifier types | `tools update`/`delete` use the tool **name** (string); `prompts get/update` use the numeric **ID**. Since v1.7 `tools get` accepts **either** (an all-digits arg is resolved ID → name via the list endpoint). Capture both name and ID from create responses — updates and deletes remain name-keyed. |
+| Update body `id` vs positional (v1.7+) | Body-routed update commands (`agents`, `prompts`, `custom-messages`, `language-groups`, `users` by email, `tools` by name; and since **v1.8** `data-sources`, `services`, `voice-groups`, `roles`, `incidents`, which previously took no positional) inject the positional identifier into the body when it's missing, and hard-error before sending if the body carries a different one. On pre-1.7 CLIs the positional was ignored and the body's `id` decided the target — so always carry the right `id` in the body (the standard get → edit → put pipe does this for you). |
+| Session ID vs Twilio call SID | `session_id`-keyed calls (`sessions get`, `GET /api/v1/sessions/full-summary/{session_id}`, `sdk.sessions.getById`) take the **numeric** Syllable session ID (e.g. `824`). A Twilio `CA<hex>` call SID is a different field — the session's `channel_manager_sid` — and returns **400** on these routes. Resolve a `CA…` SID to its session in one call: `sessions list --search-field channel_manager_sid --search "<full SID>" -o json`. (On older CLIs without `--search-field`, match the `channel_manager_sid` column on `sessions list -o json`.) |
+| Filter sessions on boolean fields client-side | Server-side `--search-field` filtering is reliable for string fields (`agent_name`, `channel_manager_sid`, `prompt_name`, …). For boolean fields (`is_outbound`, `is_test`), fetch with `-o json` and filter with `jq`, e.g. `… -o json \| jq '.items[] \| select(.is_outbound == true)'`. To *include* test sessions in a listing, use the dedicated `--include-test` flag. (Tracked in [cli#99](https://github.com/asksyllable/syllable-cli/issues/99).) |
 
 ## Variable Rendering
 
-| Issue | Details |
-|-------|---------|
-| Greetings vs prompts | Greetings use bare keys: `{{ agent_name }}`. Prompts use the `vars.` prefix: `{{vars.agent_name}}`. To ensure a variable renders in both contexts, store it with both keys on the agent: `{"agent_name": "Anna", "vars.agent_name": "Anna"}`. |
-| Variable syntax options | The platform supports three substitution formats: `{{ variable }}` (double-brace, renders blank if missing), `${variable=fallback}` (dollar-brace, renders fallback value if missing), `{variable}` (single-brace, preserves literal text if missing). See https://docs.syllable.ai/resources/Variables. |
-| Greetings cannot use campaign batch variables | Campaign batch variables (from CSV `request_variables`) do NOT render in greetings -- greetings only read agent-level variables. Keep greetings minimal for outbound agents and have the prompt speak recipient name/details. |
-| Outbound batch variables blank in test API | Campaign batch variables render as empty strings in conversation test API sessions because there is no actual campaign batch providing values. Write outbound prompt conditionals defensively: "If the value is blank, empty, missing, or anything other than exactly 'true', treat it as false." |
+| Topic | What to do |
+|-------|-----------|
+| Custom variables — one key, no `vars.` prefix | Reference a custom variable by the same bare key in greetings, prompts, and tool parameters — e.g. `{{ agent_name }}` everywhere. Don't add a `vars.` prefix or store a duplicate `vars.`-prefixed copy: per the docs, `{{ vars.agent_name }}` resolves to empty when the stored key is `agent_name`. The `vars.` prefix is only for system variables (`{{ vars.session.* }}`) and outbound-campaign variables (which the campaign system auto-prefixes). |
+| Variable syntax options | Three substitution formats: `{{ variable }}` (renders blank if missing), `${variable=fallback}` (renders the fallback if missing), `{variable}` (keeps the literal text if missing). See https://docs.syllable.ai/resources/Variables. |
+| Campaign batch variables don't reach greetings | Greetings read agent-level variables only — campaign batch variables (from CSV `request_variables`) aren't available there. Keep outbound greetings minimal and have the prompt speak recipient name/details. |
+| Batch variables in the test API | In conversation-test sessions there's no campaign batch, so batch variables resolve to empty strings. Write outbound prompt conditionals defensively: "If the value is blank, empty, missing, or anything other than exactly 'true', treat it as false." |
 
 ## Creation Ordering
 
-| Issue | Details |
-|-------|---------|
-| Tools must exist before prompt | The `tools` array on prompt create expects tool names that already exist in the org. Create tools first. |
-| Prompt create ignores tools array | The `tools` array on `prompts create` is silently ignored -- the created prompt will have an empty tools list. Always follow up with a `prompts update` call to attach tools. |
-| `prompt_tool_defaults` on agent create | If the API rejects `prompt_tool_defaults` during agent create, create the agent first without them, then update the agent to add them. |
+| Topic | What to do |
+|-------|-----------|
+| Tools before prompt | The `tools` array on prompt create references tool names that must already exist in the org — create tools first. |
+| Attach tools in a follow-up update | `prompts create` doesn't attach the `tools` array — the new prompt starts with an empty tools list. Create the prompt, then `prompts update` to attach tools. |
+| `prompt_tool_defaults` on agent create | If agent create doesn't accept `prompt_tool_defaults`, create the agent first, then update it to add them. |
 
 ## Validation
 
-| Issue | Details |
-|-------|---------|
-| Prompt updates require all fields | CLI `prompts update` requires `id`, `name`, `type`, and `llm_config` even for partial changes. Fetch the full prompt first (`prompts get <id> -o json`), modify the JSON, then resubmit. Sending only changed fields returns 422. |
-| Always set `edit_comments` on prompt create/update | Both `PromptCreateRequest` and `PromptUpdateRequest` accept `edit_comments` (string). It surfaces in the prompt's version history as the label for that revision and is the only way to tell what changed without diffing. **Always include a one-line `edit_comments` describing the change** (e.g., `"Add wheelchair-routing branch"`, `"Bump LLM to gpt-5.1"`, `"Tighten transfer guardrail"`). Omitting it leaves the version unlabeled and forces future reviewers to diff to figure out intent. |
-| Agent enum values | `stt_provider` expects values like `"Deepgram Nova 3"` (not `"deepgram"`). `wait_sound` expects `"Call Center"` (not `"office"`). Query schemas if unsure: `syllable schema get AgentSttProvider`, `syllable schema get AgentWaitSound`. |
-| Prompt text with backticks in shell | When writing prompt JSON to `/tmp/`, use Python `json.dumps()` to generate the file, not shell heredoc or echo. Backtick characters in prompt text are interpreted as command substitution by zsh, silently stripping them from the output. |
+| Topic | What to do |
+|-------|-----------|
+| Prompt updates send the full object | `prompts update` is a full PUT — include `id`, `name`, `type`, and `llm_config` (and large fields like `context`) even for a one-field change. Fetch first (`prompts get <id> -o json`), edit the JSON, resubmit; a partial body returns 422. |
+| Always set `edit_comments` on prompt create/update | Both `PromptCreateRequest` and `PromptUpdateRequest` accept `edit_comments` (string) — it's the label for that revision in version history and the quickest way to see what changed without diffing. **Always include a one-line `edit_comments`** (e.g., `"Add wheelchair-routing branch"`, `"Bump LLM to gpt-5.1"`, `"Tighten transfer guardrail"`). |
+| Agent enum values | `stt_provider` expects display values like `"Deepgram Nova 3"` (not `"deepgram"`); `wait_sound` expects `"Call Center"` (not `"office"`). Check with `syllable schema get AgentSttProvider` / `syllable schema get AgentWaitSound`. |
+| Prompt text with backticks in shell | Generate prompt JSON with Python `json.dumps()`, not a shell heredoc or `echo` — zsh treats backtick characters as command substitution and strips them from the output. |
 | Service `auth_type` for public APIs | Set to `null` (not omitted) for APIs with no authentication. |
-| Session labels are immutable | Session labels, once applied, cannot be removed or changed via the API. Apply labels carefully. |
-| Day-of-week abbreviation mismatch | Message rules use two-letter abbreviations (`mo`, `tu`, `we`, `th`, `fr`, `sa`, `su` — `DayOfWeek` enum). Campaign `active_days` use three-letter abbreviations (`mon`, `tue`, `wed`, `thu`, `fri`, `sat`, `sun` — `DaysOfWeek` enum). Using the wrong format silently fails. |
+| Session labels are immutable | Once applied, a session label can't be changed or removed via the API — apply carefully. |
+| Day-of-week abbreviations differ by context | Message rules use two-letter codes (`mo`, `tu`, `we`, `th`, `fr`, `sa`, `su` — `DayOfWeek`); campaign `active_days` use three-letter codes (`mon`, `tue`, `wed`, `thu`, `fri`, `sat`, `sun` — `DaysOfWeek`). Match the format to the context. |
 
 ## Campaign Behavior
 
-| Issue | Details |
-|-------|---------|
-| Batch deduplicates by target number | Outbound campaign batches deduplicate by `target` phone number -- if multiple batch records share the same target, only the first is dialed and the rest are marked `DUPLICATE`. Fix: use sequential batches (one record per batch) instead of a single batch with multiple records targeting the same number. |
-| `caller_id` required despite schema marking it optional | `OutboundCampaignInput` lists `caller_id` as optional (`anyOf [string, null]`), but `syllable outbound campaigns create --file payload.json` rejects with `"No agent with assign number None found"` (status 400) when `caller_id` is omitted or set to a phone without a matching channel target. Both `caller_id` and `source` should be set to the same source phone number, and a voice channel target binding that phone to the campaign's agent must already exist on the org's Twilio channel. The CLI resolves `agent_id` server-side from `caller_id` → channel target lookup, even if you also pass `agent_id` in the body. |
-| Channel target create takes channel-id as positional | `syllable channels targets create <channel-id> --file payload.json` -- the channel ID is a positional argument, not part of the JSON body (even though the body also includes a `channel_id` field). Omitting the positional fails with `accepts 1 arg(s), received 0`. |
+| Topic | What to do |
+|-------|-----------|
+| Batch dedupes by target number | An outbound batch dedupes by `target` phone number — duplicate targets in one batch dial only the first and mark the rest `DUPLICATE`. To call the same number more than once, use sequential single-record batches. |
+| Set `caller_id` (and `source`) on campaign create | Although `OutboundCampaignInput` types `caller_id` as optional (`anyOf [string, null]`), campaign create needs it: set both `caller_id` and `source` to the source phone number, and have a voice channel target binding that number to the campaign's agent already in place. The server resolves `agent_id` from `caller_id` → channel target, so that binding must exist first. (Without it: 400 "No agent with assign number None found".) |
+| Channel target create takes channel-id as a positional | `syllable channels targets create <channel-id> --file payload.json` — the channel ID is a positional argument (the body also has a `channel_id` field). Without it: "accepts 1 arg(s), received 0". |
 
 ## Conversation Test API (`send-test-message`)
 
-| Issue | Details |
-|-------|---------|
-| `--override-timestamp` only honors **timezone-naive** ISO | `syllable agents send-test-message --override-timestamp` forwards `override_timestamp` to the conversation-test API, but the server applies it **only** when given timezone-naive `YYYY-MM-DDTHH:MM:SS` (e.g. `2030-12-25T09:30:00`, interpreted in the agent's timezone). Forms with a TZ offset (`...-06:00`), a `Z`/UTC suffix, or a space separator are **silently ignored** — the agent falls back to the real wall clock with **no error** (HTTP 200). Invalid strings also return 200, *not* a 422 (`TestMessage.override_timestamp` is typed `anyOf[string,null]`, so there is no format validation). (CLI **v1.6.1** corrected the `--help` example to the tz-naive form — earlier versions shipped the offset example, a silent no-op — [cli#76](https://github.com/asksyllable/syllable-cli/issues/76)/[cli#78](https://github.com/asksyllable/syllable-cli/issues/78). CLI **v1.7** adds a **stderr warning** on the three confirmed-ignored forms — trailing `Z`, `±HH:MM` offset, space separator — while still sending the value; the warning also fires under `--dry-run`, so preflight there. The server behavior is unchanged; a server-side strictness fix is pending.) **Fix:** pass naive `YYYY-MM-DDTHH:MM:SS`, and confirm it took by checking the session transcript `actions[].tool_result` for `get_current_datetime` (or whether a time-based greeting changed) rather than trusting a green run. When honored, the override drives both `get_current_datetime` and time-based message/greeting rule selection. |
+| Topic | What to do |
+|-------|-----------|
+| `--override-timestamp` expects a timezone-naive value | Pass `YYYY-MM-DDTHH:MM:SS` with no offset, no `Z`/UTC suffix, and no space separator (e.g. `2030-12-25T09:30:00`, read in the agent's timezone) — only this form is applied; other forms fall back to the real wall clock. CLI **v1.6.1** corrected the `--help` example to the naive form; **v1.7** adds a stderr warning on the known-ignored forms (trailing `Z`, `±HH:MM` offset, space separator), which also fires under `--dry-run`. Confirm it applied by checking the session transcript `actions[].tool_result` for `get_current_datetime` (or whether a time-based greeting changed), rather than trusting a green run. When applied, the override drives both `get_current_datetime` and time-based message/greeting selection. ([cli#76](https://github.com/asksyllable/syllable-cli/issues/76), [cli#78](https://github.com/asksyllable/syllable-cli/issues/78); a server-side strictness fix is pending.) |
 
 ## Bridge Phrases (`conversation-config`)
 
-| Issue | Details |
-|-------|---------|
-| Unified `messages` accepted but not persisted (prod) | The v1.7.1 spec adds `messages` + `randomize_messages` to the bridges body, and `conversation-config bridges-update` sends them — but the **production API silently drops both** (verified live 2026-06-04: update with `messages` returned 200, immediate read-back omitted the fields). Until the backend deploys support, only the legacy lists (`first_slow_messages`, `very_slow_messages`, `tool_responses`) persist. **Always read back after a bridges-update** to confirm what actually stuck. |
-| `smart_turn_timeout_seconds` accepted but not persisted (prod) | The v1.7.2 spec adds top-level `smart_turn_timeout_seconds` (number `0.25`–`30`, or `null`) to the bridges body, and `bridges-update` passes it through via `--file`. **Verified live 2026-06-08 (CLI v1.7.3): same drift as the sibling fields above** — a `bridges-update` carrying `smart_turn_timeout_seconds` returned 200 but both the response body and the immediate read-back omitted it (sent in the same PUT as `messages`/`randomize_messages`, all three dropped). Until the backend deploys support it does not persist; **read back to confirm**. Tracked alongside [cli#100](https://github.com/asksyllable/syllable-cli/issues/100). |
+| Topic | What to do |
+|-------|-----------|
+| Unified `messages` / `randomize_messages` not yet active in prod | The v1.7.1 spec adds `messages` + `randomize_messages` to the bridges body and `bridges-update` sends them, but production doesn't persist them yet — until it does, only the legacy lists (`first_slow_messages`, `very_slow_messages`, `tool_responses`) take effect. Read back after a `bridges-update` to confirm what applied. |
+| `smart_turn_timeout_seconds` not yet active in prod | Same for the top-level `smart_turn_timeout_seconds` (number `0.25`–`30`, or `null`): `bridges-update` passes it through via `--file`, but production doesn't persist it yet. Read back to confirm. (Tracked alongside [cli#100](https://github.com/asksyllable/syllable-cli/issues/100).) |
 
 ## Channels (`channels targets`)
 
-| Issue | Details |
-|-------|---------|
-| `--search-field target_mode_list` rejected by prod (422) | The v1.7.3 spec sync ([cli#106](https://github.com/asksyllable/syllable-cli/issues/106)) added `target_mode_list` to the channel-target `search_fields` vocabulary — a filter-only field meant to match a comma-separated list of modes, used as `channels targets list --search-field target_mode_list --search "voice,sms"`. **Prod rejects it with 422** ("Input should be 'id', 'channel_id', … 'a2p_verified'") — prod's `search_fields` enum has the other 10 members but not `target_mode_list`. Verified live 2026-06-08 (CLI v1.7.3); a 422 enum error is raised before data evaluation, and the singular `target_mode` / default `target` search fields return 200 on the same org, so the search mechanism works — only this field is rejected. **Fix until the backend deploys it:** filter client-side, e.g. `channels targets list -o json \| jq '.items[] \| select(.target_mode == "voice" or .target_mode == "sms")'`. Tracked in [cli#109](https://github.com/asksyllable/syllable-cli/issues/109). (The companion `order_by` change in the same sync — new `ChannelTargetOrderProperties` enum — has **no CLI surface**: `channels targets list` exposes no `--order-by` flag, and the accepted sort fields are unchanged.) |
+| Topic | What to do |
+|-------|-----------|
+| `target_mode_list` search field not yet in prod | The v1.7.3 spec ([cli#106](https://github.com/asksyllable/syllable-cli/issues/106)) lists `target_mode_list` in the channel-target `search_fields` vocabulary — a filter meant to match a comma-separated list of modes (`channels targets list --search-field target_mode_list --search "voice,sms"`) — but production's `search_fields` enum doesn't accept it yet (422). Until it does, filter client-side: `channels targets list -o json \| jq '.items[] \| select(.target_mode == "voice" or .target_mode == "sms")'`. The singular `target_mode` and the default `target` search fields work normally. (Tracked in [cli#109](https://github.com/asksyllable/syllable-cli/issues/109).) The companion `order_by` change in the same sync has no CLI surface — `channels targets list` exposes no `--order-by` flag. |
 
 ## Deprecations
 
-| Issue | Details |
-|-------|---------|
-| Language Groups renamed to Voice Groups | The `language-groups` commands still work but the platform renamed them to Voice Groups. Use `voice-groups` commands for new work. The Console shows "Voices" not "Language Groups." |
-| Agent `label` (singular) deprecated → `labels` (plural) | The agent field `label` (singular string) is deprecated. Use `labels` (array of strings). Old payloads with `label` may silently ignore the value. The same applies to campaigns — use `labels` (array) instead of `label` (string). |
+| Topic | What to do |
+|-------|-----------|
+| Language Groups renamed to Voice Groups | The `language-groups` commands still work, but the platform renamed them to Voice Groups — use `voice-groups` for new work. The Console shows "Voices," not "Language Groups." |
+| Agent/campaign `label` (singular) → `labels` (plural) | Use `labels` (array of strings); the singular `label` field is deprecated and an old payload using it may not apply the value. The same applies to campaigns. |
 
 ## Known Gaps
 
-| Issue | Details |
-|-------|---------|
-| Step tools — schema only, no CLI commands | The API schema defines `Step`, `StepTools`, `StepEventActions`, and `NextStep` types, but the CLI has no `steps` or `step-tools` commands. Manage step tools through the Console or SDK until CLI support is added. |
+| Topic | What to do |
+|-------|-----------|
+| Step tools — Console/SDK only | The schema defines `Step`, `StepTools`, `StepEventActions`, and `NextStep`, but the CLI has no `steps` or `step-tools` commands yet — manage step tools through the Console or SDK. |
 
 ## Users
 
-| Issue | Details |
-|-------|---------|
-| `users create` 500s for existing-globally emails | If the email already has an identity in Syllable (e.g., the user exists in another org, or has a Google Workspace account), `POST /api/v1/users/` returns an opaque `500 "An error occurred while creating the user"` unless the payload includes `"skip_auth": true` AND an explicit `"login_type"`. The OpenAPI schema lists `skip_auth` as defaulting to `false`, but the Console always sends `skipAuth: true`. Without it, the server tries to provision a fresh auth identity for an already-known email and crashes internally. See `payload-examples.md` § *User Create — Add to Org*. |
-| Inline-create integer flags now send as integers (v1.8) | `--role-id` (`users create`), `--prompt-id` (`agents create`), `--service-id` (`tools create`), and `--campaign-id` (`outbound batches create`) now parse and send as JSON integers, with a clear error on a non-numeric value. Pre-1.8 they serialized as strings (e.g. `"19"`) and relied on the server coercing them — on older CLIs use `--file` with the unquoted integer (`"role_id": 19`) instead. |
-| `users get <id>` not supported | The `users get` command takes the **email** as the positional argument, not the numeric ID. Passing an integer returns `"<id> is not a valid email address"`. |
-| `users me` needs your email configured | The API has no key→identity endpoint, so `users me` can only do an exact lookup of the email set via `syllable setup`. Since CLI v1.7 it **fails loudly** without one (`Error: no email configured — run \`syllable setup\` …`, exit 1). Pre-1.7 it silently returned the **first user in the org** — never trust its output on older versions to confirm which account a key belongs to. |
-| Choosing `login_type` | Use `"google"` for Google Workspace domains. Use `"username_and_password"` for everything else. The schema default is `"google"` only for `@gmail.com` — every other domain defaults to username/password, which is wrong for Workspace SSO orgs. |
+| Topic | What to do |
+|-------|-----------|
+| `users create` for an email that already exists platform-wide | If the email already has a Syllable identity (the user exists in another org, or has a Google Workspace account), include `"skip_auth": true` **and** an explicit `"login_type"` in the create body — this matches what the Console sends (`skipAuth: true`). Without them the server tries to provision a fresh auth identity for an already-known email and returns a 500. See `payload-examples.md` § *User Create — Add to Org*. |
+| Inline-create integer flags send as integers (v1.8) | `--role-id` (`users create`), `--prompt-id` (`agents create`), `--service-id` (`tools create`), and `--campaign-id` (`outbound batches create`) parse and send as JSON integers, with a clear error on a non-numeric value. On pre-1.8 CLIs they serialized as strings — use `--file` with the unquoted integer (`"role_id": 19`) instead. |
+| `users get` is keyed by email | `users get <email>` takes the **email**, not the numeric ID — an integer returns "<id> is not a valid email address". |
+| `users me` needs your email configured | The API has no key→identity endpoint, so `users me` does an exact lookup of the email set via `syllable setup`. Since v1.7 it fails clearly without one (`Error: no email configured — run \`syllable setup\` …`, exit 1). Pre-1.7 it returned the org's first user, so don't rely on older versions to confirm which account a key belongs to. |
+| Choosing `login_type` | Use `"google"` for Google Workspace domains and `"username_and_password"` for everything else. The schema defaults to `"google"` only for `@gmail.com`, so set it explicitly for Workspace SSO orgs on other domains. |
 
 ## LLM Config
 
-| Issue | Details |
-|-------|---------|
-| Always use `syllable prompts supported-llms` | The `supported-llms` command returns all valid provider/model/version/api_version combos. `syllable schema get PromptLlmProvider` is stale and does not reflect all supported providers (e.g., it omits `anthropic`). |
-| LLM config requires exact `version` and `api_version` fields | Sending only `provider` + `model` will fail with HTTP 400. Copy the exact values from `supported-llms`. Examples: voice agents — `{ "provider": "openai", "model": "gpt-4.1", "version": "2025-04-14", "api_version": null, "temperature": 0.0 }`; chat agents — `{ "provider": "openai", "model": "gpt-5.1", "version": "2025-11-13", "api_version": null, "temperature": null }`. (gpt-4o is being discontinued — do not use as a default.) |
-| GPT-5 family requires `temperature: null` | The models gpt-5, gpt-5-mini, gpt-5.1, and gpt-5.2 do not support the temperature parameter. Setting `temperature: 0.0` lets the prompt update succeed and the agent greeting fire, but the second user message returns HTTP 400. Set `temperature: null` for these models. |
+| Topic | What to do |
+|-------|-----------|
+| Use `syllable prompts supported-llms` for valid combos | `supported-llms` returns the current provider/model/version/api_version combinations. Prefer it over `syllable schema get PromptLlmProvider`, which may not list every supported provider (e.g. `anthropic`). |
+| LLM config needs exact `version` and `api_version` | `provider` + `model` alone returns 400 — copy `version` and `api_version` verbatim from `supported-llms`. Examples: voice — `{ "provider": "openai", "model": "gpt-4.1", "version": "2025-04-14", "api_version": null, "temperature": 0.0 }`; chat — `{ "provider": "openai", "model": "gpt-5.1", "version": "2025-11-13", "api_version": null, "temperature": null }`. (gpt-4o is being discontinued — don't default to it.) |
+| GPT-5 family uses `temperature: null` | gpt-5, gpt-5-mini, gpt-5.1, and gpt-5.2 don't take a temperature parameter — set `temperature: null`. (With `temperature: 0.0` the greeting fires but a later user turn returns 400.) |

--- a/.claude/skills/syllable-cli/references/variables-and-messages.md
+++ b/.claude/skills/syllable-cli/references/variables-and-messages.md
@@ -79,7 +79,7 @@ Messages are configurable greetings or email templates delivered at the start of
 | `type` | enum | no | `greeting` (default) or `email_template` |
 | `label` | string | no | Label for filtering in the Console |
 | `preamble` | string | no | Uninterruptible prefix delivered before the main message (e.g., legal disclaimers). Cannot contain `{{ language.mode }}` |
-| `subject` | string | no | Email subject line. **Only valid for `email_template` type** — using it on a `greeting` causes an API rejection |
+| `subject` | string | no | Email subject line. **Only accepted on `email_template`** — including it on a `greeting` is rejected with a 422 (`subject is only allowed when type is email_template`) |
 | `rules` | array | no | Time-based rules for conditional message variants (default: `[]`) |
 
 ### Language Menu Tag

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -453,7 +453,7 @@ Text knowledge bases for agents. Name must have no whitespace. Content should st
 syllable data-sources list [--page N] [--limit N] [--search TEXT]
 syllable data-sources get <data-source-id>
 syllable data-sources create --file source.json
-syllable data-sources create --name NAME --description DESC --content TEXT
+syllable data-sources create --name NAME --description DESC --text TEXT
 syllable data-sources update --file source.json
 syllable data-sources delete <data-source-id>
 ```

--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -1098,7 +1098,7 @@ func TestDataSourcesList(t *testing.T) {
 	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"items": []map[string]interface{}{
-				{"id": "1", "name": "FAQ Data", "description": "FAQ content", "last_updated": "2024-01-01"},
+				{"id": "1", "name": "FAQ Data", "description": "FAQ content", "updated_at": "2024-01-01"},
 			},
 			"total_count": 1,
 		})
@@ -1114,6 +1114,10 @@ func TestDataSourcesList(t *testing.T) {
 	if !strings.Contains(out, "FAQ Data") {
 		t.Errorf("output should contain data source name, got: %s", out)
 	}
+	// The LAST_UPDATED column reads the API's "updated_at" field.
+	if !strings.Contains(out, "2024-01-01") {
+		t.Errorf("output should show the updated_at value, got: %s", out)
+	}
 }
 
 func TestDataSourcesGet(t *testing.T) {
@@ -1121,7 +1125,7 @@ func TestDataSourcesGet(t *testing.T) {
 	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		requestPath = r.URL.Path
 		json.NewEncoder(w).Encode(map[string]interface{}{
-			"id": "5", "name": "FAQ Data", "content": "Some FAQ content",
+			"id": "5", "name": "FAQ Data", "text": "Some FAQ content", "updated_at": "2024-02-02",
 		})
 	})
 	defer server.Close()
@@ -1137,6 +1141,43 @@ func TestDataSourcesGet(t *testing.T) {
 	}
 	if !strings.Contains(out, "FAQ Data") {
 		t.Errorf("output should contain data source name, got: %s", out)
+	}
+	// The detail view reads the API's "text" field (not "content").
+	if !strings.Contains(out, "Some FAQ content") {
+		t.Errorf("output should contain the data source text, got: %s", out)
+	}
+}
+
+func TestDataSourcesCreateWithFlags(t *testing.T) {
+	var receivedBody map[string]interface{}
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedBody)
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"id":1}`))
+	})
+	defer server.Close()
+
+	cmd := dataSourcesCreateCmd()
+	cmd.SetArgs([]string{"--name", "FAQ", "--text", "Q&A text"})
+	captureStdout(func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// The document body field is "text" (not "content"), and "chunk" is required.
+	if receivedBody["text"] != "Q&A text" {
+		t.Errorf("expected text=Q&A text, got %#v", receivedBody["text"])
+	}
+	if _, ok := receivedBody["chunk"]; !ok {
+		t.Error("expected required chunk field in body")
+	}
+	if _, ok := receivedBody["content"]; ok {
+		t.Errorf("body must not contain a phantom 'content' field, got %#v", receivedBody["content"])
+	}
+	if receivedBody["name"] != "FAQ" {
+		t.Errorf("expected name=FAQ, got %#v", receivedBody["name"])
 	}
 }
 

--- a/scripts/syllable-cli/cmd/data_sources.go
+++ b/scripts/syllable-cli/cmd/data_sources.go
@@ -73,7 +73,7 @@ func dataSourcesListCmd() *cobra.Command {
 					ID          json.Number `json:"id"`
 					Name        string      `json:"name"`
 					Description string      `json:"description"`
-					LastUpdated string      `json:"last_updated"`
+					LastUpdated string      `json:"updated_at"`
 					LastUpdBy   string      `json:"last_updated_by"`
 				} `json:"items"`
 				TotalCount int `json:"total_count"`
@@ -127,8 +127,9 @@ func dataSourcesGetCmd() *cobra.Command {
 				ID          json.Number `json:"id"`
 				Name        string      `json:"name"`
 				Description string      `json:"description"`
-				Content     string      `json:"content"`
-				LastUpdated string      `json:"last_updated"`
+				Text        string      `json:"text"`
+				Chunk       bool        `json:"chunk"`
+				UpdatedAt   string      `json:"updated_at"`
 				LastUpdBy   string      `json:"last_updated_by"`
 			}
 			if err := json.Unmarshal(data, &d); err != nil {
@@ -140,8 +141,9 @@ func dataSourcesGetCmd() *cobra.Command {
 				{"ID", d.ID.String()},
 				{"Name", d.Name},
 				{"Description", d.Description},
-				{"Content", output.Truncate(d.Content, 100)},
-				{"Last Updated", d.LastUpdated},
+				{"Text", output.Truncate(d.Text, 100)},
+				{"Chunk", fmt.Sprintf("%t", d.Chunk)},
+				{"Updated At", d.UpdatedAt},
 				{"Last Updated By", d.LastUpdBy},
 			}
 			printTable([]string{"FIELD", "VALUE"}, rows)
@@ -151,7 +153,7 @@ func dataSourcesGetCmd() *cobra.Command {
 }
 
 func dataSourcesCreateCmd() *cobra.Command {
-	var file, name, description, content string
+	var file, name, description, text string
 
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -168,13 +170,17 @@ func dataSourcesCreateCmd() *cobra.Command {
 					return fmt.Errorf("parsing JSON file: %w", err)
 				}
 			} else {
-				if name == "" {
-					return fmt.Errorf("required flags: --name (or use --file)")
+				if name == "" || text == "" {
+					return fmt.Errorf("required flags: --name, --text (or use --file)")
 				}
+				// The document body field is "text" (not "content"), and "chunk"
+				// is required by the API even though it is currently ignored
+				// server-side (treated as false).
 				body = map[string]interface{}{
 					"name":        name,
 					"description": description,
-					"content":     content,
+					"text":        text,
+					"chunk":       false,
 				}
 			}
 
@@ -191,7 +197,7 @@ func dataSourcesCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&file, "file", "", "Path to JSON body file")
 	cmd.Flags().StringVar(&name, "name", "", "Data source name")
 	cmd.Flags().StringVar(&description, "description", "", "Description")
-	cmd.Flags().StringVar(&content, "content", "", "Content text")
+	cmd.Flags().StringVar(&text, "text", "", "Document text the data source provides to the agent")
 
 	return cmd
 }


### PR DESCRIPTION
## What
Fixes a real bug in `data-sources create` and corrects the usage skill after a fact-check against docs.syllable.ai and the embedded OpenAPI spec.

## Data source bug (code)
- Inline `create` built a body with a `content` field the API doesn't define and omitted the required `text`/`chunk` → it always 422'd. Now sends `--text` + `chunk:false`.
- `get`/`list` tables read `content`/`last_updated`, but the API returns `text`/`updated_at`, so those columns were always blank. Fixed; `get` also shows `chunk`.
- Added `TestDataSourcesCreateWithFlags`; updated the list/get stubs to the real field names.
- **Verified live** on the `cli-test` org: inline create now succeeds, the detail view renders Text/Chunk/Updated At, and the old `--content` path reproduced the 422.

## Skill (docs)
- Professionalized the tone (removed "silently…"/"crashes internally"/dated forensic logs; reframed each entry as usage guidance).
- Corrected the `vars.` variable-prefix guidance to match docs + the skill's own detailed reference: custom variables use the same bare key everywhere; `vars.` is only for system (`vars.session.*`) and auto-prefixed campaign variables.
- Corrected greeting `subject`: rejected with a 422 on a greeting (confirmed live).
- Synced AGENTS.md for the flag change.

## Tests
`gofmt`, `go vet`, `go build`, and the full unit suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
