### PR TITLE
chore: bump skill docs marker to v2.0.0

### DIFF
--- a/.claude/skills/syllable-cli/SKILL.md
+++ b/.claude/skills/syllable-cli/SKILL.md
@@ -9,9 +9,9 @@ description: |
 
 A Go CLI for managing the Syllable AI platform. Source and releases: **https://github.com/asksyllable/syllable-cli**
 
-> **Docs synced to CLI v1.8.0** (pending release) — bump this marker whenever these docs are updated for a new release.
+> **Docs synced to CLI v2.0.0** — bump this marker whenever these docs are updated for a new release.
 >
-> v1.8.0 highlights for CLI users: destructive `delete` commands now confirm interactively and need `--yes` when non-interactive; `channels delete` was removed (no such API op — use `channels targets delete`); `--output` is validated; unknown `--fields` columns warn; `--dry-run` lists any `missing_required_fields`; `--debug` redacts credentials; `data-sources create` inline now takes `--text` (the document-body field) in place of the old, non-functional `--content`.
+> v2.0.0 (major) highlights — note the breaking changes for CLI users: destructive `delete` commands now confirm interactively and need `--yes` when non-interactive; `channels delete` was removed (no such API op — use `channels targets delete`); `data-sources create` inline now takes `--text` (the document-body field) in place of the old, non-functional `--content`. Also: `--output` is validated; unknown `--fields` columns warn; `--dry-run` lists any `missing_required_fields`; `--debug` redacts credentials.
 
 ## Installation
 


### PR DESCRIPTION
Relabels the usage-skill sync marker (`Docs synced to CLI v…`) and the highlights list from v1.8.0 to **v2.0.0**, ahead of cutting the 2.0.0 release.

2.0.0 is a major bump because the accumulated work since v1.7.4 includes breaking changes: `delete` commands now require confirmation / `--yes`, `channels delete` was removed, and `data-sources create` inline switched `--content` → `--text`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
