### PR TITLE
feat: sync CLI to OpenAPI spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,6 +331,7 @@ Individual voice or chat conversations. Captures transcript, AI summary, tool ca
 syllable sessions list [--page N] [--limit N] [--start-date DATE] [--end-date DATE]
 syllable sessions get <session-id>
 syllable sessions transcript <session-id>
+syllable sessions timeline <session-id>
 syllable sessions summary <session-id>
 syllable sessions latency <session-id>
 syllable sessions recording <session-id>

--- a/README.md
+++ b/README.md
@@ -358,12 +358,13 @@ syllable tools history <id>
 
 ### Sessions
 
-Sessions are individual voice or chat conversations. Each session captures the transcript, an AI summary, all tool calls with their arguments and API responses, duration (for voice), channel, and test/live status. Use `transcript`, `summary`, `latency`, and `recording` subcommands to pull specific session data.
+Sessions are individual voice or chat conversations. Each session captures the transcript, an AI summary, all tool calls with their arguments and API responses, duration (for voice), channel, and test/live status. Use `transcript`, `timeline`, `summary`, `latency`, and `recording` subcommands to pull specific session data. The `timeline` subcommand returns a single consolidated, time-ordered stream of transcript turns, tool calls, and latency events with offsets from the session start.
 
 ```bash
 syllable sessions list [--start-date DATE] [--end-date DATE]
 syllable sessions get <id>
 syllable sessions transcript <id>
+syllable sessions timeline <id>
 syllable sessions summary <id>
 syllable sessions latency <id>
 syllable sessions recording <id>

--- a/scripts/syllable-cli/cmd/sessions.go
+++ b/scripts/syllable-cli/cmd/sessions.go
@@ -44,6 +44,7 @@ func sessionsCmd() *cobra.Command {
 	cmd.AddCommand(sessionsListCmd())
 	cmd.AddCommand(sessionsGetCmd())
 	cmd.AddCommand(sessionsTranscriptCmd())
+	cmd.AddCommand(sessionsTimelineCmd())
 	cmd.AddCommand(sessionsSummaryCmd())
 	cmd.AddCommand(sessionsLatencyCmd())
 	cmd.AddCommand(sessionsRecordingCmd())
@@ -276,6 +277,64 @@ func sessionsTranscriptCmd() *cobra.Command {
 			rows := make([][]string, len(result.Transcription))
 			for i, t := range result.Transcription {
 				rows[i] = []string{t.Timestamp, t.Source, output.Truncate(t.Text, 80)}
+			}
+			printTable(headers, rows)
+			return nil
+		},
+	}
+}
+
+func sessionsTimelineCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "timeline <session-id>",
+		Short: "Get the consolidated, time-ordered timeline for a session",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, _, err := apiClient.Get("/api/v1/sessions/timeline/" + url.PathEscape(args[0]))
+			if err != nil {
+				return err
+			}
+
+			if getOutputFmt() == "json" {
+				output.PrintJSON(data)
+				return nil
+			}
+
+			var result struct {
+				SessionID string `json:"session_id"`
+				Events    []struct {
+					Kind       string   `json:"kind"`
+					Offset     string   `json:"offset"`
+					Source     *string  `json:"source"`
+					Text       *string  `json:"text"`
+					Label      *string  `json:"label"`
+					DurationMs *float64 `json:"duration_ms"`
+				} `json:"events"`
+			}
+			if err := json.Unmarshal(data, &result); err != nil {
+				output.PrintJSON(data)
+				return nil
+			}
+
+			fmt.Printf("Session: %s\n\n", result.SessionID)
+			headers := []string{"OFFSET", "KIND", "SOURCE", "LABEL", "DETAIL"}
+			rows := make([][]string, len(result.Events))
+			for i, e := range result.Events {
+				src := ""
+				if e.Source != nil {
+					src = *e.Source
+				}
+				lbl := ""
+				if e.Label != nil {
+					lbl = *e.Label
+				}
+				detail := ""
+				if e.Text != nil && *e.Text != "" {
+					detail = output.Truncate(*e.Text, 60)
+				} else if e.DurationMs != nil {
+					detail = fmt.Sprintf("%.0f ms", *e.DurationMs)
+				}
+				rows[i] = []string{e.Offset, e.Kind, src, lbl, detail}
 			}
 			printTable(headers, rows)
 			return nil

--- a/scripts/syllable-cli/integration/integration_test.go
+++ b/scripts/syllable-cli/integration/integration_test.go
@@ -17,6 +17,7 @@
 package integration_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/signal"
@@ -469,6 +470,35 @@ func TestAgentsLabels(t *testing.T) {
 	// on a non-zero exit, so a clean call proves the command, path, and auth all
 	// work against the live API.
 	mustRunCLI(t, "agents", "labels")
+}
+
+// ---------------------------------------------------------------------------
+// Session Timeline (read-only) — spec-sync
+// ---------------------------------------------------------------------------
+
+func TestSessionsTimeline(t *testing.T) {
+	// List sessions, then fetch the timeline for the first one. A fresh CI org
+	// may have no sessions, so skip rather than fail when the list is empty.
+	// --include-test so a throwaway CI org (whose sessions are likely test
+	// sessions) still has a session to exercise the timeline endpoint against.
+	out := mustRunCLI(t, "sessions", "list", "--limit", "1", "--include-test")
+	var listed struct {
+		Items []struct {
+			SessionID string `json:"session_id"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(out, &listed); err != nil {
+		t.Fatalf("parse sessions list: %v (raw: %s)", err, string(out))
+	}
+	if len(listed.Items) == 0 || listed.Items[0].SessionID == "" {
+		t.Skip("no sessions in this org; skipping timeline test")
+	}
+
+	// A clean exit proves the path, auth, and response parsing all work.
+	timeline := mustRunCLI(t, "sessions", "timeline", listed.Items[0].SessionID)
+	if !json.Valid(timeline) {
+		t.Fatalf("timeline output is not valid JSON: %s", string(timeline))
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/syllable-cli/internal/spec/openapi.json
+++ b/scripts/syllable-cli/internal/spec/openapi.json
@@ -7589,6 +7589,54 @@
         }
       }
     },
+    "/api/v1/sessions/timeline/{session_id}": {
+      "get": {
+        "tags": [
+          "sessions.timeline"
+        ],
+        "summary": "Get Session Timeline By Id",
+        "description": "Consolidated, time-ordered timeline of a session's events.",
+        "operationId": "session_timeline_get_by_id",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionTimelineResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/session_debug/sid/{channel_manager_service}/{channel_manager_sid}": {
       "get": {
         "tags": [
@@ -14687,7 +14735,7 @@
             "title": "Batch Id",
             "description": "Unique ID for conversation batch",
             "examples": [
-              "20260610.9"
+              "20260624.9"
             ]
           },
           "campaign_id": {
@@ -14711,7 +14759,7 @@
             "title": "Expires On",
             "description": "Timestamp of batch expiration",
             "examples": [
-              "2026-06-11T00:00:00Z"
+              "2026-06-25T00:00:00Z"
             ]
           },
           "paused": {
@@ -14779,7 +14827,7 @@
             "title": "Created At",
             "description": "Timestamp of batch creation",
             "examples": [
-              "2026-06-10T00:00:00Z"
+              "2026-06-24T00:00:00Z"
             ]
           },
           "deleted_at": {
@@ -14795,7 +14843,7 @@
             "title": "Deleted At",
             "description": "Timestamp of batch deletion",
             "examples": [
-              "2026-06-10T00:00:00Z"
+              "2026-06-24T00:00:00Z"
             ]
           },
           "deleted_reason": {
@@ -14826,7 +14874,7 @@
             "title": "Last Updated At",
             "description": "Timestamp of last change to batch",
             "examples": [
-              "2026-06-10T00:00:00Z"
+              "2026-06-24T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -15053,7 +15101,10 @@
               }
             ],
             "title": "Delete Comments",
-            "description": "Comments explaining the deletion"
+            "description": "Comments explaining the deletion",
+            "examples": [
+              "Deleted the organization because it was no longer needed"
+            ]
           }
         },
         "type": "object",
@@ -15961,7 +16012,7 @@
             "title": "Batch Id",
             "description": "Unique ID for conversation batch",
             "examples": [
-              "20260610.9"
+              "20260624.9"
             ]
           },
           "campaign_id": {
@@ -15985,7 +16036,7 @@
             "title": "Expires On",
             "description": "Timestamp of batch expiration",
             "examples": [
-              "2026-06-11T00:00:00Z"
+              "2026-06-25T00:00:00Z"
             ]
           },
           "paused": {
@@ -16053,7 +16104,7 @@
             "title": "Created At",
             "description": "Timestamp of batch creation",
             "examples": [
-              "2026-06-10T00:00:00Z"
+              "2026-06-24T00:00:00Z"
             ]
           },
           "deleted_at": {
@@ -16069,7 +16120,7 @@
             "title": "Deleted At",
             "description": "Timestamp of batch deletion",
             "examples": [
-              "2026-06-10T00:00:00Z"
+              "2026-06-24T00:00:00Z"
             ]
           },
           "deleted_reason": {
@@ -16100,7 +16151,7 @@
             "title": "Last Updated At",
             "description": "Timestamp of last change to batch",
             "examples": [
-              "2026-06-10T00:00:00Z"
+              "2026-06-24T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -16143,7 +16194,7 @@
             "title": "Batch Id",
             "description": "Unique ID for conversation batch",
             "examples": [
-              "20260610.9"
+              "20260624.9"
             ]
           },
           "campaign_id": {
@@ -16167,7 +16218,7 @@
             "title": "Expires On",
             "description": "Timestamp of batch expiration",
             "examples": [
-              "2026-06-11T00:00:00Z"
+              "2026-06-25T00:00:00Z"
             ]
           },
           "paused": {
@@ -16316,7 +16367,7 @@
             "title": "Created At",
             "description": "Timestamp of request creation",
             "examples": [
-              "2026-06-09T00:00:00Z"
+              "2026-06-23T00:00:00Z"
             ]
           },
           "sent_at": {
@@ -16332,7 +16383,7 @@
             "title": "Sent At",
             "description": "Timestamp at which request was sent",
             "examples": [
-              "2026-06-10T00:00:00Z"
+              "2026-06-24T00:00:00Z"
             ]
           },
           "attempt_count": {
@@ -19732,7 +19783,7 @@
             "title": "Created At",
             "description": "Timestamp at which insight upload folder was created",
             "examples": [
-              "2026-06-09T00:00:00Z"
+              "2026-06-23T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -19741,7 +19792,7 @@
             "title": "Updated At",
             "description": "Timestamp at which insight upload folder was last updated",
             "examples": [
-              "2026-06-10T00:00:00Z"
+              "2026-06-24T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -20744,7 +20795,7 @@
             "title": "Created At",
             "description": "Timestamp of at which insight tool configuration was created",
             "examples": [
-              "2026-06-09T00:00:00Z"
+              "2026-06-23T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -20753,7 +20804,7 @@
             "title": "Updated At",
             "description": "Timestamp at which insight tool configuration was last updated",
             "examples": [
-              "2026-06-10T00:00:00Z"
+              "2026-06-24T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -21134,7 +21185,7 @@
             "title": "Start Datetime",
             "description": "Target session timestamp the workflow (backfill) should start. An empty value indicates start on activation - live sessions only",
             "examples": [
-              "2026-06-09T00:00:00Z"
+              "2026-06-23T00:00:00Z"
             ]
           },
           "end_datetime": {
@@ -21150,7 +21201,7 @@
             "title": "End Datetime",
             "description": "Target session timestamp the workflow (backfill) should end. An empty value indicates no end, i.e., include live sessions until deactivation",
             "examples": [
-              "2026-06-10T00:00:00Z"
+              "2026-06-24T00:00:00Z"
             ]
           }
         },
@@ -21225,7 +21276,7 @@
             "title": "Start Datetime",
             "description": "Target session timestamp the workflow (backfill) should start. An empty value indicates start on activation - live sessions only",
             "examples": [
-              "2026-06-09T00:00:00Z"
+              "2026-06-23T00:00:00Z"
             ]
           },
           "end_datetime": {
@@ -21241,7 +21292,7 @@
             "title": "End Datetime",
             "description": "Target session timestamp the workflow (backfill) should end. An empty value indicates no end, i.e., include live sessions until deactivation",
             "examples": [
-              "2026-06-10T00:00:00Z"
+              "2026-06-24T00:00:00Z"
             ]
           },
           "id": {
@@ -21309,7 +21360,7 @@
             "title": "Created At",
             "description": "Timestamp at which the insight workflow was created",
             "examples": [
-              "2026-06-09T00:00:00Z"
+              "2026-06-23T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -21318,7 +21369,7 @@
             "title": "Updated At",
             "description": "Timestamp of most recent update to the insight workflow",
             "examples": [
-              "2026-06-10T00:00:00Z"
+              "2026-06-24T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -21414,7 +21465,7 @@
             "title": "Created At",
             "description": "Timestamp at which insight upload folder was created",
             "examples": [
-              "2026-06-09T00:00:00Z"
+              "2026-06-23T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -21423,7 +21474,7 @@
             "title": "Updated At",
             "description": "Timestamp at which insight upload folder was last updated",
             "examples": [
-              "2026-06-10T00:00:00Z"
+              "2026-06-24T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -21673,7 +21724,7 @@
             "title": "Created At",
             "description": "Timestamp at which insight tool result was created",
             "examples": [
-              "2026-06-09T00:00:00Z"
+              "2026-06-23T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -21682,7 +21733,7 @@
             "title": "Updated At",
             "description": "Timestamp at which insight tool result was last updated",
             "examples": [
-              "2026-06-10T00:00:00Z"
+              "2026-06-24T00:00:00Z"
             ]
           },
           "upload_file_metadata": {
@@ -21827,7 +21878,7 @@
             "title": "Start Time",
             "description": "Start time of the uploaded file",
             "examples": [
-              "2026-06-09T00:00:00Z"
+              "2026-06-23T00:00:00Z"
             ]
           },
           "end_time": {
@@ -21843,7 +21894,7 @@
             "title": "End Time",
             "description": "End time of the uploaded file",
             "examples": [
-              "2026-06-10T00:00:00Z"
+              "2026-06-24T00:00:00Z"
             ]
           },
           "error_message": {
@@ -21898,7 +21949,7 @@
             "title": "Created At",
             "description": "Timestamp at which insight upload file was created",
             "examples": [
-              "2026-06-09T00:00:00Z"
+              "2026-06-23T00:00:00Z"
             ]
           }
         },
@@ -25673,7 +25724,7 @@
             "title": "Created At",
             "description": "Timestamp of campaign creation",
             "examples": [
-              "2026-06-10T00:00:00Z"
+              "2026-06-24T00:00:00Z"
             ]
           },
           "updated_at": {
@@ -25682,7 +25733,7 @@
             "title": "Updated At",
             "description": "Timestamp of campaign update",
             "examples": [
-              "2026-06-10T00:00:00Z"
+              "2026-06-24T00:00:00Z"
             ]
           },
           "last_updated_by": {
@@ -28244,6 +28295,18 @@
             ],
             "title": "Tool Error",
             "description": "Error received from the tool API, if applicable"
+          },
+          "duration_ms": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Ms",
+            "description": "How long the tool invocation took, in milliseconds"
           }
         },
         "type": "object",
@@ -28711,6 +28774,43 @@
         ],
         "title": "SessionText",
         "description": "Information about a given message from a user to an agent or vice-versa."
+      },
+      "SessionTimelineResponse": {
+        "properties": {
+          "session_id": {
+            "type": "string",
+            "title": "Session Id",
+            "description": "Internal ID of the session"
+          },
+          "session_start": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Start",
+            "description": "Timestamp of the first event; the zero point for all offsets"
+          },
+          "events": {
+            "items": {
+              "$ref": "#/components/schemas/TimelineEvent"
+            },
+            "type": "array",
+            "title": "Events",
+            "description": "All events, ordered by timestamp ascending"
+          }
+        },
+        "type": "object",
+        "required": [
+          "session_id",
+          "events"
+        ],
+        "title": "SessionTimelineResponse",
+        "description": "Consolidated, time-ordered timeline of a session's events."
       },
       "SessionTranscriptionResponse": {
         "properties": {
@@ -29755,6 +29855,194 @@
         ],
         "title": "TestMessageResponse",
         "description": "Response from an agent in a test chat."
+      },
+      "TimelineEvent": {
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/TimelineEventKind",
+            "description": "Which stream this event came from"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timestamp",
+            "description": "Absolute time of the event (for ordering)"
+          },
+          "offset": {
+            "type": "string",
+            "title": "Offset",
+            "description": "Time since session start, formatted MM:SS (or HH:MM:SS)",
+            "examples": [
+              "00:04"
+            ]
+          },
+          "turn_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Turn Index",
+            "description": "0-based index of the transcript turn. Transcript events carry their own turn index; tool/latency events carry the index of the nearest preceding turn they bind to. None only for non-transcript events that precede the first transcript turn."
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source",
+            "description": "\"user\" or \"agent\" (transcript events)"
+          },
+          "text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Text",
+            "description": "Message content (transcript events)"
+          },
+          "lang": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lang",
+            "description": "Language code (transcript events)"
+          },
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category",
+            "description": "tool | llm | tts | stt | http. A tool call surfaces once, as a `kind=tool` event; its redundant tool-latency measurement is dropped from the timeline.",
+            "examples": [
+              "tool",
+              "llm"
+            ]
+          },
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label",
+            "description": "Tool name (tool events) or the latency measurement name (e.g. stt_processing)",
+            "examples": [
+              "holiday_check",
+              "stt_processing"
+            ]
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata",
+            "description": "Provider/model parts of a latency label",
+            "examples": [
+              [
+                "Gpt-4.1",
+                "OpenAI"
+              ]
+            ]
+          },
+          "duration_ms": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Ms",
+            "description": "Duration of the event in milliseconds"
+          },
+          "tool_request": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Request",
+            "description": "Tool request payload, JSON-encoded"
+          },
+          "tool_result": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Result",
+            "description": "Tool response payload, JSON-encoded"
+          },
+          "tool_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Error",
+            "description": "Tool error payload, JSON-encoded"
+          }
+        },
+        "type": "object",
+        "required": [
+          "kind",
+          "timestamp",
+          "offset"
+        ],
+        "title": "TimelineEvent",
+        "description": "A single normalized event on the consolidated session timeline."
+      },
+      "TimelineEventKind": {
+        "type": "string",
+        "enum": [
+          "transcript",
+          "tool",
+          "latency"
+        ],
+        "title": "TimelineEventKind"
       },
       "ToolAgentInfo": {
         "properties": {


### PR DESCRIPTION
Syncs the CLI to the latest upstream OpenAPI spec. **Purely additive** — adds one new read-only command and supporting schemas; nothing removed, narrowed, or newly required.

## What changed

Adds `syllable sessions timeline <session-id>` for the new endpoint `GET /api/v1/sessions/timeline/{session_id}`. It returns a single consolidated, time-ordered stream of a session's transcript turns, tool calls, and latency events, each with an offset from session start. Mirrors the existing `transcript` command (read-only GET, JSON or table output).

A live integration test (`TestSessionsTimeline`) lists one session — with `--include-test` so a throwaway CI org still has a session to exercise — fetches its timeline, and asserts valid JSON. It skips cleanly when the org has no sessions.

## diff_specs.py report

```
## NEW PATHS (1)
+ /api/v1/sessions/timeline/{session_id}
  GET — Get Session Timeline By Id ['sessions.timeline']

## NEW SCHEMAS (3)
+ SessionTimelineResponse
+ TimelineEvent
+ TimelineEventKind

## CHANGED SCHEMAS — field-level diffs (1)
~ SessionAction
  + duration_ms: anyOf   (new optional response field; no flag/body change)

## CHANGED ENUMS — member diffs (1)
~ TimelineEventKind   (new enum: transcript, tool, latency)

## SUMMARY
  Paths:   +1 added, -0 removed, ~0 changed
  Schemas: +3 added, -0 removed, ~1 changed
  Enums:   ~1 changed (0 with removed values — breaking)
```

## Breaking changes

None. No removed commands/flags, no removed enum values, no newly-required fields, no narrowed types. `SessionAction.duration_ms` is a new *optional* response field (the `latency` command prints raw JSON, so it flows through with no code change).

## Release notes

- **New:** `syllable sessions timeline <session-id>` — a consolidated, time-ordered view of a session combining transcript turns, tool calls, and latency events with offsets from the session start.

---

No `spec-drift` issue is open at reconcile time (the daily detector hasn't filed one for this change), so there is no issue to `Closes`. It self-heals: once this merges, the embedded spec matches upstream and the detector files nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
