### PR TITLE
feat: support optional agent_id/tool_name query params on conversation-config bridges

### DIFF
--- a/.claude/skills/syllable-cli/SKILL.md
+++ b/.claude/skills/syllable-cli/SKILL.md
@@ -167,7 +167,7 @@ syllable <resource> delete <id> --yes            # destructive — see note belo
 | `session-debug` | `by-session-id <id>`, `by-sid <id> <sid>`, `tool-result <id> <tool-result-id>` |
 | `takeouts` | `create --file …`, `get <id>`, `download <id> <file>` |
 | `incidents` | `organizations` |
-| `conversation-config` | `bridges`, `bridges-update --file …` |
+| `conversation-config` | `bridges`, `bridges-update --file …` — both take optional `--agent-id`/`--tool-name` to scope the config to an agent or tool (v2.1); omit for the org default |
 | `dashboards` | `list`, `sessions`, `session-events`, `session-transfers`, `session-summary`, `fetch-info --name <name>` |
 | `schema` | `list [--filter X]`, `get <SchemaName>` (local OpenAPI lookup, no API call; `-o json` is pure JSON since v1.7 — pipe straight to `jq`) |
 | `status` | no verb — prints all configured orgs/envs (read-only, local config) |

--- a/.claude/skills/syllable-cli/references/commands.md
+++ b/.claude/skills/syllable-cli/references/commands.md
@@ -410,9 +410,14 @@ syllable permissions list
 
 ## Conversation Config
 ```bash
-syllable conversation-config bridges                          # get bridge phrases (Console: Voices → Phrases)
+syllable conversation-config bridges                          # get org-default bridge phrases (Console: Voices → Phrases)
+syllable conversation-config bridges --agent-id 768           # agent-scoped (falls back to org default if no override)
+syllable conversation-config bridges --tool-name transfer_call # tool-scoped
 syllable conversation-config bridges-update --file bridges.json
+syllable conversation-config bridges-update --agent-id 768 --file bridges.json  # agent-scoped override
 ```
+
+**Scoping (CLI v2.1+):** both `bridges` and `bridges-update` accept optional `--agent-id <id>` and `--tool-name <name>` query parameters (combinable). Omitting both targets the org-level default. A scoped GET falls back to the org default when no override exists; a scoped PUT creates/updates that override without touching the org default. `--agent-id` is only sent when explicitly set, so an unset flag is not confused with `--agent-id 0`.
 
 **Unified messages (v1.7.1 spec):** the bridges body now supports an ordered `messages` list plus `randomize_messages` (bool, no-repeat shuffling). When `messages` is non-empty it replaces the three legacy lists (`first_slow_messages`, `very_slow_messages`, `tool_responses`); when empty, the legacy fields still apply. Both `bridges` commands are pass-through `--file` bodies. **Caveat:** production doesn't persist these fields yet — read back after updating to confirm (see `gotchas.md` § *Bridge Phrases*). Field semantics in `telephony-and-channels.md` § *Bridge Phrases*.
 

--- a/.claude/skills/syllable-cli/references/telephony-and-channels.md
+++ b/.claude/skills/syllable-cli/references/telephony-and-channels.md
@@ -126,7 +126,13 @@ A target links a channel to an agent, allowing users to reach the agent through 
 
 ## Responsive Dialogue (ReDi) — Bridge Phrases
 
-When `async_enabled` is true, the agent uses holding phrases to fill silence during LLM processing delays. Bridge phrases are configured at the **agent level** (not the channel level) via `conversation-config bridges`.
+When `async_enabled` is true, the agent uses holding phrases to fill silence during LLM processing delays. Bridge phrases are managed via `conversation-config bridges` and can be scoped at **three levels** (not the channel level):
+
+- **Org default** — plain `bridges` / `bridges-update` with no scope flags.
+- **Per-agent** — add `--agent-id <id>` to either command.
+- **Per-tool** — add `--tool-name <name>` (may be combined with `--agent-id`).
+
+Both `--agent-id` and `--tool-name` are optional query parameters (CLI v2.1+). A scoped GET falls back to the org default when no override exists for that agent/tool; a scoped PUT creates/updates the override without touching the org default. The API does not validate that the agent/tool exists — an unknown value simply returns the org default.
 
 Bridge phrase schema (`BridgePhraseMessages`) per language:
 
@@ -144,17 +150,22 @@ The top-level `BridgePhrasesConfig` carries the same fields plus `localized` (pe
 |-------|------|-------------|
 | `smart_turn_timeout_seconds` | number \| null | **CLI v1.7.2+ spec.** Seconds of caller silence before the agent injects the *first* bridge phrase. Range `0.25`–`30`. Subsequent sleep intervals scale to 2x / 3x / 4x this base. When unset (`null`), the service-wide default applies. |
 
-> **Not yet live on the production API** (verified 2026-06-04): `bridges-update` accepts `messages`/`randomize_messages` with 200 but the fields are silently dropped — read back to confirm. See `gotchas.md` § *Bridge Phrases*.
->
-> **`smart_turn_timeout_seconds`** (CLI v1.7.2+) is documented from the v1.7.2 release notes / spec — not live-verified. Like the other new fields it passes through the `--file` body untyped; whether the production backend persists it is unconfirmed, so read back after updating.
+> **Persistence — agent-scoped writes now stick** (verified 2026-07-09 on the `cli-test` org): an `--agent-id`-scoped `bridges-update` persisted both `messages` and `smart_turn_timeout_seconds`, confirmed by read-back. This supersedes the earlier 2026-06-04 note that these fields were silently dropped on 200. Org-default (unscoped) persistence was not separately re-verified in that run — still read back to confirm. See `gotchas.md` § *Bridge Phrases*.
 
 Manage via CLI:
 ```bash
-# View current bridge phrases
+# View the org-default bridge phrases
 syllable conversation-config bridges
 
-# Update bridge phrases
+# View an agent- or tool-scoped config (falls back to org default if no override)
+syllable conversation-config bridges --agent-id 768
+syllable conversation-config bridges --tool-name transfer_call
+
+# Update the org default
 syllable conversation-config bridges-update --file bridges.json
+
+# Create/update an agent-scoped override (leaves the org default untouched)
+syllable conversation-config bridges-update --agent-id 768 --file bridges.json
 ```
 
 ## Campaign Voicemail Detection

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -549,6 +549,12 @@ Bridge phrases — the filler messages an agent speaks while it is delayed or a 
 syllable conversation-config bridges
 syllable conversation-config bridges-update --file bridges.json
 ```
+Both commands accept optional `--agent-id <id>` and `--tool-name <name>` query parameters to scope the config to a specific agent or tool; omit both for the org-level default config.
+```bash
+syllable conversation-config bridges --agent-id 42
+syllable conversation-config bridges --tool-name transfer_call
+syllable conversation-config bridges-update --agent-id 42 --file bridges.json
+```
 
 ### Dashboards
 **DEPRECATION WARNING:** The `sessions`, `session-events`, `session-transfers`, and `session-summary` subcommands are deprecated. Use `list` and `fetch-info` instead.

--- a/scripts/syllable-cli/cmd/cmd_test.go
+++ b/scripts/syllable-cli/cmd/cmd_test.go
@@ -2153,6 +2153,105 @@ func TestConversationConfigBridges(t *testing.T) {
 	}
 }
 
+func TestConversationConfigBridgesQueryParams(t *testing.T) {
+	var query string
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		query = r.URL.RawQuery
+		json.NewEncoder(w).Encode(map[string]interface{}{})
+	})
+	defer server.Close()
+
+	cmd := conversationConfigBridgesGetCmd()
+	cmd.SetArgs([]string{"--agent-id", "42", "--tool-name", "transfer_call"})
+	captureStdout(func() {
+		cmd.Execute()
+	})
+
+	if !strings.Contains(query, "agent_id=42") {
+		t.Errorf("expected agent_id=42 in query, got: %s", query)
+	}
+	if !strings.Contains(query, "tool_name=transfer_call") {
+		t.Errorf("expected tool_name=transfer_call in query, got: %s", query)
+	}
+}
+
+func TestConversationConfigBridgesNoQueryParams(t *testing.T) {
+	var query string
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		query = r.URL.RawQuery
+		json.NewEncoder(w).Encode(map[string]interface{}{})
+	})
+	defer server.Close()
+
+	// Unset --agent-id must not be sent as agent_id=0.
+	cmd := conversationConfigBridgesGetCmd()
+	cmd.SetArgs([]string{})
+	captureStdout(func() {
+		cmd.Execute()
+	})
+
+	if query != "" {
+		t.Errorf("expected no query params, got: %s", query)
+	}
+}
+
+func TestConversationConfigBridgesExplicitAgentIDZero(t *testing.T) {
+	var query string
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		query = r.URL.RawQuery
+		json.NewEncoder(w).Encode(map[string]interface{}{})
+	})
+	defer server.Close()
+
+	// An explicit --agent-id 0 is distinct from the flag being unset.
+	cmd := conversationConfigBridgesGetCmd()
+	cmd.SetArgs([]string{"--agent-id", "0"})
+	captureStdout(func() {
+		cmd.Execute()
+	})
+
+	if !strings.Contains(query, "agent_id=0") {
+		t.Errorf("expected agent_id=0 in query, got: %s", query)
+	}
+}
+
+func TestConversationConfigBridgesUpdateQueryParams(t *testing.T) {
+	var method, requestPath, query string
+	var receivedBody map[string]interface{}
+	server := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		requestPath = r.URL.Path
+		query = r.URL.RawQuery
+		json.NewDecoder(r.Body).Decode(&receivedBody)
+		json.NewEncoder(w).Encode(map[string]interface{}{})
+	})
+	defer server.Close()
+
+	tmp := filepath.Join(t.TempDir(), "bridges.json")
+	if err := os.WriteFile(tmp, []byte(`{"messages":["one moment"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := conversationConfigBridgesUpdateCmd()
+	cmd.SetArgs([]string{"--agent-id", "42", "--file", tmp})
+	captureStdout(func() {
+		cmd.Execute()
+	})
+
+	if method != "PUT" {
+		t.Errorf("expected PUT, got %s", method)
+	}
+	if requestPath != "/api/v1/conversation-config/bridges" {
+		t.Errorf("unexpected request path: %s", requestPath)
+	}
+	if !strings.Contains(query, "agent_id=42") {
+		t.Errorf("expected agent_id=42 in query, got: %s", query)
+	}
+	if receivedBody["messages"] == nil {
+		t.Errorf("expected messages in request body, got: %v", receivedBody)
+	}
+}
+
 // --- Spec-sync v0.0.3: new command coverage ---
 
 func TestAgentsLabels(t *testing.T) {

--- a/scripts/syllable-cli/cmd/conversation_config.go
+++ b/scripts/syllable-cli/cmd/conversation_config.go
@@ -3,10 +3,31 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"strconv"
 
 	"github.com/asksyllable/syllable-cli/internal/output"
 	"github.com/spf13/cobra"
 )
+
+// bridgesQuery builds the optional query string shared by the bridge phrases
+// GET and PUT endpoints. Both accept an optional agent_id and tool_name to
+// scope the config to a specific agent or tool; when neither is set the
+// org-level default config is used. agent_id is only sent when the flag was
+// explicitly set so an unset flag is not confused with a literal 0.
+func bridgesQuery(cmd *cobra.Command, agentID int, toolName string) string {
+	params := url.Values{}
+	if cmd.Flags().Changed("agent-id") {
+		params.Set("agent_id", strconv.Itoa(agentID))
+	}
+	if toolName != "" {
+		params.Set("tool_name", toolName)
+	}
+	if len(params) == 0 {
+		return ""
+	}
+	return "?" + params.Encode()
+}
 
 func conversationConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -26,8 +47,15 @@ overrides are also supported.`,
   # Get bridge phrases configuration as JSON
   syllable conversation-config bridges --output json
 
+  # Get the config scoped to a specific agent or tool
+  syllable conversation-config bridges --agent-id 42
+  syllable conversation-config bridges --tool-name transfer_call
+
   # Update the bridge phrases configuration from a JSON file
-  syllable conversation-config bridges-update --file bridges.json`,
+  syllable conversation-config bridges-update --file bridges.json
+
+  # Update the config scoped to a specific agent
+  syllable conversation-config bridges-update --agent-id 42 --file bridges.json`,
 	}
 
 	cmd.AddCommand(conversationConfigBridgesGetCmd())
@@ -37,11 +65,15 @@ overrides are also supported.`,
 }
 
 func conversationConfigBridgesGetCmd() *cobra.Command {
-	return &cobra.Command{
+	var agentID int
+	var toolName string
+
+	cmd := &cobra.Command{
 		Use:   "bridges",
 		Short: "Get bridge phrases configuration (Console: Voices → Phrases)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			data, _, err := apiClient.Get("/api/v1/conversation-config/bridges")
+			path := "/api/v1/conversation-config/bridges" + bridgesQuery(cmd, agentID, toolName)
+			data, _, err := apiClient.Get(path)
 			if err != nil {
 				return err
 			}
@@ -49,10 +81,16 @@ func conversationConfigBridgesGetCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().IntVar(&agentID, "agent-id", 0, "Agent ID to fetch config for")
+	cmd.Flags().StringVar(&toolName, "tool-name", "", "Tool name to fetch config for")
+	return cmd
 }
 
 func conversationConfigBridgesUpdateCmd() *cobra.Command {
 	var file string
+	var agentID int
+	var toolName string
 
 	cmd := &cobra.Command{
 		Use:   "bridges-update",
@@ -72,7 +110,8 @@ func conversationConfigBridgesUpdateCmd() *cobra.Command {
 				return fmt.Errorf("use --file to provide bridges update body")
 			}
 
-			data, _, err := apiClient.Put("/api/v1/conversation-config/bridges", body)
+			path := "/api/v1/conversation-config/bridges" + bridgesQuery(cmd, agentID, toolName)
+			data, _, err := apiClient.Put(path, body)
 			if err != nil {
 				return err
 			}
@@ -83,5 +122,7 @@ func conversationConfigBridgesUpdateCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&file, "file", "", "Path to JSON body file")
+	cmd.Flags().IntVar(&agentID, "agent-id", 0, "Agent ID to update config for")
+	cmd.Flags().StringVar(&toolName, "tool-name", "", "Tool name to update config for")
 	return cmd
 }


### PR DESCRIPTION
## What

Both `GET` and `PUT /api/v1/conversation-config/bridges` accept optional `agent_id` and `tool_name` query parameters to scope the bridge phrases config to a specific agent or tool. The CLI previously ignored them, so only the org-level default config was ever reachable.

This adds `--agent-id` and `--tool-name` flags to both `conversation-config bridges` (GET) and `conversation-config bridges-update` (PUT).

## Details

- New shared helper `bridgesQuery` builds the query string for both commands.
- `agent_id` is only sent when `--agent-id` is **explicitly set** (via `cmd.Flags().Changed`), so an unset flag isn't confused with a literal `0`. An explicit `--agent-id 0` *is* sent.
- Omitting both flags sends the bare endpoint with no query string (org-level default config), preserving existing behavior.
- No spec change: these parameters already exist in the embedded OpenAPI spec; this is pure command wiring + docs.

## Testing

- Unit tests added: both params set, no-params (the 0-vs-unset guard), explicit `--agent-id 0`, and the update command's query + body. Full suite green.
- Verified live against the `cli-test` org:
  - Each flag serializes correctly (`?agent_id=768`, `?tool_name=hangup`, and both combined); all return HTTP 200.
  - Confirmed the scoping is real: writing an agent-specific config via `bridges-update --agent-id 768` created a per-agent override without touching the org default — subsequent `bridges --agent-id 768` returned the override while `bridges` (no flag) still returned the org default.

## Docs

- Updated `AGENTS.md` Conversation Config section and the command's inline examples.